### PR TITLE
Emails sent by mail check don't indicate they're from django-watchman

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -41,7 +41,7 @@ class TestWatchman(unittest.TestCase):
         self.assertEqual(response['Content-Type'], 'application/json')
 
     def test_response_contains_expected_checks(self):
-        expected_checks = ['caches', 'databases', 'email', ]
+        expected_checks = ['caches', 'databases', ]
         request = RequestFactory().get('/')
         response = views.status(request)
 
@@ -64,7 +64,7 @@ class TestWatchman(unittest.TestCase):
         self.assertIn(response['foo']['error'], expected_error)
 
     def test_response_skipped_checks(self):
-        expected_checks = ['caches', 'email', ]
+        expected_checks = ['caches', ]
         request = RequestFactory().get('/', data={
             'skip': 'watchman.checks.databases_status',
         })

--- a/watchman/checks.py
+++ b/watchman/checks.py
@@ -6,7 +6,7 @@ import traceback
 import uuid
 from django.conf import settings
 from django.core.cache import get_cache
-from django.core.mail import send_mail
+from django.core.mail import EmailMessage
 from django.db import connections
 
 
@@ -55,7 +55,15 @@ def _check_database(database):
 
 def _check_email():
     try:
-        send_mail("subject", "message", "from@example.com", ["to@example.com"])
+        headers = {"X-DJANGO-WATCHMAN": True}
+        email = EmailMessage(
+            "django-watchman email check",
+            "This is an automated test of the email system.",
+            "watchman@example.com",
+            ["to@example.com"],
+            headers=headers
+        )
+        email.send()
         response = {"ok": True}
     except Exception as e:
         response = {

--- a/watchman/settings.py
+++ b/watchman/settings.py
@@ -6,7 +6,6 @@ WATCHMAN_TOKEN_NAME = getattr(settings, 'WATCHMAN_TOKEN_NAME', 'watchman-token')
 DEFAULT_CHECKS = (
     'watchman.checks.caches_status',
     'watchman.checks.databases_status',
-    'watchman.checks.email_status',
 )
 
 WATCHMAN_CHECKS = getattr(settings, 'WATCHMAN_CHECKS', DEFAULT_CHECKS)


### PR DESCRIPTION
### TODO
- [x] Update readme once changes from #7 are in

It would be nice if the emails sent by the `_check_email` [function](https://github.com/mwarkentin/django-watchman/blob/master/watchman/checks.py#L56) had a body/subject/headers that indicated they were generated by `django-watchman`, in order to aid debugging of email servers and unexpected email volume.

We should also indicate somewhere that this check might cost users money, if they check `django-watchman` especially aggressively - for example, checking once per minute would cost a ~$5.60/month if Mandrill is used for sending.