### PR TITLE
28: Add `WATCHMAN_ENABLE_PAID_CHECKS` setting

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,7 @@ History
   * Add ``X-DJANGO-WATCHMAN: True`` custom header
 * Add new default check: ``storage`` check
   * Checks that files can be both written and read with the current Django storage engine
+  * Add ``WATCHMAN_ENABLE_PAID_CHECKS`` setting to enable all paid checks without modifying ``WATCHMAN_CHECKS``
 * Remove ``email_status`` from default checks
 * Refactor ``utils.get_checks`` to allow reuse in management command
   * ``get_checks`` now performs the optional check inclusion / skipping

--- a/README.rst
+++ b/README.rst
@@ -201,3 +201,10 @@ Default checks
 By default, django-watchman will run checks against your databases
 (``watchman.checks.databases``), caches (``watchman.checks.caches``), and
 storage (``watchman.checks.storage``).
+
+Paid checks
+***********
+
+Currently there is only one "paid" check - ``watchman.checks.email``. You can
+enable it by setting the ``WATCHMAN_ENABLE_PAID_CHECKS`` to ``True``, or by
+overriding the ``WATCHMAN_CHECKS`` setting.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,3 +53,12 @@ class TestWatchman(unittest.TestCase):
         checks = [check.__name__ for check in get_checks(check_list=check_list, skip_list=skip_list)]
         expected_checks = ['databases']
         self.assertListsEqual(checks, expected_checks)
+
+    def test_get_checks_with_paid_checks_disabled_returns_expected_checks(self):
+        expected_checks = ['caches', 'databases', 'storage']
+        checks = [check.__name__ for check in get_checks()]
+        self.assertListsEqual(checks, expected_checks)
+
+    @unittest.skip("Unsure how to test w/ modified settings")
+    def test_get_checks_with_paid_checks_enabled_returns_expected_checks(self):
+        pass

--- a/watchman/settings.py
+++ b/watchman/settings.py
@@ -1,12 +1,20 @@
 from django.conf import settings
 
 # TODO: these should not be module level.
+WATCHMAN_ENABLE_PAID_CHECKS = getattr(settings, 'WATCHMAN_ENABLE_PAID_CHECKS', False)
 WATCHMAN_TOKEN = getattr(settings, 'WATCHMAN_TOKEN', None)
 WATCHMAN_TOKEN_NAME = getattr(settings, 'WATCHMAN_TOKEN_NAME', 'watchman-token')
+
 DEFAULT_CHECKS = (
     'watchman.checks.caches',
     'watchman.checks.databases',
     'watchman.checks.storage',
 )
+PAID_CHECKS = (
+    'watchman.checks.email',
+)
+
+if WATCHMAN_ENABLE_PAID_CHECKS:
+    DEFAULT_CHECKS = DEFAULT_CHECKS + PAID_CHECKS
 
 WATCHMAN_CHECKS = getattr(settings, 'WATCHMAN_CHECKS', DEFAULT_CHECKS)


### PR DESCRIPTION
Adds a setting which allows you to bulk enable / disable any checks
which may cost money (currently just `email`). Adds some partial
tests (unable to figure out how to test with an overridden setting at
this point).

Docs are updated as well.

Fixes #28.