### PR TITLE
Fix #33: Add `X-Watchman-Version` header to responses

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,12 +5,14 @@ History
 0.6.0 (2015-07-??)
 ++++++++++++++++++
 
-* [[#30](https://github.com/mwarkentin/django-watchman/pull/30)] Allow users to specify a custom authentication/authorization decorator
-  * Override the `@auth` decorator by setting `WATCHMAN_AUTH_DECORATOR` to a dot-separated path to your own decorator
-  * eg. `WATCHMAN_AUTH_DECORATOR = 'django.contrib.admin.views.decorators.staff_member_required'`
-  * Token-based authentication remains the default
-* [[#31](https://github.com/mwarkentin/django-watchman/pull/31)] Add a human-friendly status dashboard
-  * Available at `<watchman url>/dashboard/`
+* [`#30 <https://github.com/mwarkentin/django-watchman/pull/30>`_] Allow users to specify a custom authentication/authorization decorator
+ * Override the ``@auth`` decorator by setting ``WATCHMAN_AUTH_DECORATOR`` to a dot-separated path to your own decorator
+ * eg. ``WATCHMAN_AUTH_DECORATOR = 'django.contrib.admin.views.decorators.staff_member_required'``
+ * Token-based authentication remains the default
+* [`#31 <https://github.com/mwarkentin/django-watchman/pull/31>`_], [`#34 <https://github.com/mwarkentin/django-watchman/pull/34>`_] Add a human-friendly status dashboard
+ * Available at ``<watchman url>/dashboard/``
+ * ``?check`` & ``?skip`` GET params work on the dashboard as well
+* [`#35 <https://github.com/mwarkentin/django-watchman/pull/35>`_] Add ``X-Watchman-Version`` header to responses
 
 0.5.0 (2015-01-25)
 ++++++++++++++++++

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -171,6 +171,11 @@ class TestWatchman(unittest.TestCase):
         response = views.status(request)
         self.assertEqual(response.status_code, 200)
 
+    def test_response_version_header(self):
+        request = RequestFactory().get('/')
+        response = views.status(request)
+        self.assertTrue(response.has_header('X-Watchman-Version'))
+
     def tearDown(self):
         pass
 
@@ -184,3 +189,8 @@ class TestWatchmanDashboard(unittest.TestCase):
         request = RequestFactory().get('/')
         response = views.dashboard(request)
         self.assertEqual(response.status_code, 200)
+
+    def test_response_version_header(self):
+        request = RequestFactory().get('/')
+        response = views.dashboard(request)
+        self.assertTrue(response.has_header('X-Watchman-Version'))

--- a/watchman/views.py
+++ b/watchman/views.py
@@ -7,8 +7,12 @@ from django.shortcuts import render
 from django.utils.translation import ugettext as _
 
 from jsonview.decorators import json_view
+from watchman import __version__
 from watchman.decorators import auth
 from watchman.utils import get_checks
+
+
+WATCHMAN_VERSION_HEADER = 'X-Watchman-Version'
 
 
 @auth
@@ -32,7 +36,7 @@ def status(request):
     if len(response) == 0:
         raise Http404(_('No checks found'))
 
-    return response
+    return response, 200, {WATCHMAN_VERSION_HEADER: __version__}
 
 
 @auth
@@ -110,7 +114,10 @@ def dashboard(request):
 
     overall_status = all([type_status['ok'] for type_status in check_types])
 
-    return render(request, 'watchman/dashboard.html', {
+    response = render(request, 'watchman/dashboard.html', {
         'checks': check_types,
         'overall_status': overall_status
     })
+
+    response[WATCHMAN_VERSION_HEADER] = __version__
+    return response


### PR DESCRIPTION
* Add response header
* Add tests for dashboard / watchman json views
* Update history.rst

### Response headers (json)

```
Connection:keep-alive
Content-Encoding:gzip
Content-Type:application/json
Date:Thu, 02 Jul 2015 19:06:48 GMT
Server:nginx/1.0.15
Transfer-Encoding:chunked
Vary:Accept-Encoding
X-Watchman-Version:0.6.0a0
```

### Response headers (dashboard)

```
Connection:keep-alive
Content-Encoding:gzip
Content-Type:text/html; charset=utf-8
Date:Thu, 02 Jul 2015 19:31:34 GMT
Server:nginx/1.0.15
Transfer-Encoding:chunked
Vary:Accept-Encoding
X-Watchman-Version:0.6.0a0
```