### PR TITLE
Support for returning code 500 if there are errors

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -176,6 +176,24 @@ class TestWatchman(unittest.TestCase):
         response = views.status(request)
         self.assertTrue(response.has_header('X-Watchman-Version'))
 
+    @patch('watchman.checks._check_databases')
+    @override_settings(WATCHMAN_ERROR_CODE=503)
+    def test_response_error_code(self, patched_check_databases):
+        reload_settings()
+        # Fake a DB error, ensure we get our error code
+        patched_check_databases.return_value = [{
+            "foo": {
+                "ok": False,
+                "error": "Fake DB Error",
+                "stacktrace": "Fake DB Stack Trace",
+            },
+        }]
+        request = RequestFactory().get('/', data={
+            'check': 'watchman.checks.databases',
+        })
+        response = views.status(request)
+        self.assertEqual(response.status_code, 503)
+
     def tearDown(self):
         pass
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -178,7 +178,7 @@ class TestWatchman(unittest.TestCase):
 
     @patch('watchman.checks._check_databases')
     @override_settings(WATCHMAN_ERROR_CODE=503)
-    def test_response_error_code(self, patched_check_databases):
+    def test_custom_error_code(self, patched_check_databases):
         reload_settings()
         # Fake a DB error, ensure we get our error code
         patched_check_databases.return_value = [{
@@ -193,6 +193,23 @@ class TestWatchman(unittest.TestCase):
         })
         response = views.status(request)
         self.assertEqual(response.status_code, 503)
+
+    @patch('watchman.checks._check_databases')
+    def test_default_error_code(self, patched_check_databases):
+        reload_settings()
+        # Fake a DB error, ensure we get our error code
+        patched_check_databases.return_value = [{
+            "foo": {
+                "ok": False,
+                "error": "Fake DB Error",
+                "stacktrace": "Fake DB Stack Trace",
+            },
+        }]
+        request = RequestFactory().get('/', data={
+            'check': 'watchman.checks.databases',
+        })
+        response = views.status(request)
+        self.assertEqual(response.status_code, 200)
 
     def tearDown(self):
         pass

--- a/watchman/settings.py
+++ b/watchman/settings.py
@@ -5,7 +5,7 @@ WATCHMAN_ENABLE_PAID_CHECKS = getattr(settings, 'WATCHMAN_ENABLE_PAID_CHECKS', F
 WATCHMAN_AUTH_DECORATOR = getattr(settings, 'WATCHMAN_AUTH_DECORATOR', 'watchman.decorators.token_required')
 WATCHMAN_TOKEN = getattr(settings, 'WATCHMAN_TOKEN', None)
 WATCHMAN_TOKEN_NAME = getattr(settings, 'WATCHMAN_TOKEN_NAME', 'watchman-token')
-WATCHMAN_500_ERRORS = getattr(settings, 'WATCHMAN_500_ERRORS', False)
+WATCHMAN_ERROR_CODE = getattr(settings, 'WATCHMAN_ERROR_CODE', 200)
 
 DEFAULT_CHECKS = (
     'watchman.checks.caches',

--- a/watchman/settings.py
+++ b/watchman/settings.py
@@ -5,6 +5,7 @@ WATCHMAN_ENABLE_PAID_CHECKS = getattr(settings, 'WATCHMAN_ENABLE_PAID_CHECKS', F
 WATCHMAN_AUTH_DECORATOR = getattr(settings, 'WATCHMAN_AUTH_DECORATOR', 'watchman.decorators.token_required')
 WATCHMAN_TOKEN = getattr(settings, 'WATCHMAN_TOKEN', None)
 WATCHMAN_TOKEN_NAME = getattr(settings, 'WATCHMAN_TOKEN_NAME', 'watchman-token')
+WATCHMAN_500_ERRORS = getattr(settings, 'WATCHMAN_500_ERRORS', False)
 
 DEFAULT_CHECKS = (
     'watchman.checks.caches',

--- a/watchman/views.py
+++ b/watchman/views.py
@@ -39,19 +39,18 @@ def status(request):
     for check in get_checks(check_list=check_list, skip_list=skip_list):
         if callable(check):
             _check = check()
-            # If WATCHMAN_500_ERRORS=True, we return an HTTP code 500
-            # when any checks are failed. Otherwise always return 200.
-            if settings.WATCHMAN_500_ERRORS:
+            # Set our HTTP status code if there were any errors
+            if settings.WATCHMAN_ERROR_CODE:
                 for _type in _check:
                     if type(_check[_type]) == dict:
                         result = _check[_type]
                         if not result['ok']:
-                            http_code = 500
+                            http_code = settings.WATCHMAN_ERROR_CODE
                     elif type(_check[_type]) == list:
                         for entry in _check[_type]:
                             for result in entry:
                                 if not entry[result]['ok']:
-                                    http_code = 500
+                                    http_code = settings.WATCHMAN_ERROR_CODE
             response.update(_check)
 
     if len(response) == 0:

--- a/watchman/views.py
+++ b/watchman/views.py
@@ -5,8 +5,8 @@ from __future__ import unicode_literals
 from django.http import Http404
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
-
 from jsonview.decorators import json_view
+from watchman import settings
 from watchman import __version__
 from watchman.decorators import auth
 from watchman.utils import get_checks
@@ -32,17 +32,32 @@ def _get_check_params(request):
 @json_view
 def status(request):
     response = {}
+    http_code = 200
 
     check_list, skip_list = _get_check_params(request)
 
     for check in get_checks(check_list=check_list, skip_list=skip_list):
         if callable(check):
-            response.update(check())
+            _check = check()
+            # If WATCHMAN_500_ERRORS=True, we return an HTTP code 500
+            # when any checks are failed. Otherwise always return 200.
+            if settings.WATCHMAN_500_ERRORS:
+                for _type in _check:
+                    if type(_check[_type]) == dict:
+                        result = _check[_type]
+                        if not result['ok']:
+                            http_code = 500
+                    elif type(_check[_type]) == list:
+                        for entry in _check[_type]:
+                            for result in entry:
+                                if not entry[result]['ok']:
+                                    http_code = 500
+            response.update(_check)
 
     if len(response) == 0:
         raise Http404(_('No checks found'))
 
-    return response, 200, {WATCHMAN_VERSION_HEADER: __version__}
+    return response, http_code, {WATCHMAN_VERSION_HEADER: __version__}
 
 
 @auth

--- a/watchman/views.py
+++ b/watchman/views.py
@@ -40,7 +40,7 @@ def status(request):
         if callable(check):
             _check = check()
             # Set our HTTP status code if there were any errors
-            if settings.WATCHMAN_ERROR_CODE:
+            if settings.WATCHMAN_ERROR_CODE != 200:
                 for _type in _check:
                     if type(_check[_type]) == dict:
                         result = _check[_type]


### PR DESCRIPTION
At my company we use an HTTP-based health check for our web applications. It is very simple, in that it does not parse the body of the response at all, it simply checks the return code for either 200 or 500, and assumes the app is up or down accordingly.

This commit adds a new setting to django-watchman, WATCHMAN_500_ERRORS. If set to True, watchman's status page will have an http code of 500 whenever ANY check is failed, code 200 if all checks are OK. If set to False (the default), the current behavior is maintained (status page is always 200).

For the most part I simply copied the code from the dashboard() view that does the same thing, and simplified it for the status() view.