### PR TITLE
Fixed typographical error, changed aggresive to aggressive in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -199,7 +199,7 @@ email
 Send a test email to ``to@example.com`` using ``django.core.mail.send_mail``.
 
 If you're using a 3rd party mail provider, this check could end up costing you
-money, depending how aggresive you are with your monitoring. For this reason,
+money, depending how aggressive you are with your monitoring. For this reason,
 this check is **not enabled** by default.
 
 For reference, if you were using Mandrill, and hitting your watchman endpoint


### PR DESCRIPTION
@mwarkentin, I've corrected a typographical error in the documentation of the [django-watchman](https://github.com/mwarkentin/django-watchman) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.