### PR TITLE
Fixes #50: Updates django urlpatterns

### DIFF
--- a/watchman/urls.py
+++ b/watchman/urls.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns(
-    '',
-    url(r'^$', 'watchman.views.status', name="status"),
-    url(r'^dashboard/$', 'watchman.views.dashboard', name="dashboard"),
-)
+from watchman import views
+
+
+urlpatterns = [
+    url(r'^$', views.status, name="status"),
+    url(r'^dashboard/$', views.dashboard, name="dashboard"),
+]


### PR DESCRIPTION
New convention is to just use a list of callables, rather than magic
strings in the `pattern()` function. The old way would be removed in
Django 1.10.