### PR TITLE
Provide error response decorator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,8 +110,11 @@ the ``WATCHMAN_CHECKS`` setting. In ``settings.py``::
         'another.module.path.to.callable',
     )
 
-Checks take no arguments, and must return a ``dict`` whose keys are applied to the JSON response::
+Checks take no arguments, and must return a ``dict`` whose keys are applied to the JSON response. Use the ``watchman.decorators.check`` decorator to capture exceptions::
 
+    from watchman.decorators import check
+
+    @check
     def my_check():
         return {'x': 1}
 

--- a/watchman/checks.py
+++ b/watchman/checks.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 
-import traceback
 import uuid
 from django.conf import settings
 from django.core.cache import get_cache
@@ -11,87 +10,58 @@ from django.core.files.storage import default_storage
 from django.core.mail import EmailMessage
 from django.db import connections
 
+from watchman.decorators import check
+
 
 def _check_caches(caches):
     return [_check_cache(cache) for cache in caches]
 
 
+@check
 def _check_cache(cache_name):
     key = 'django-watchman-{}'.format(uuid.uuid4())
     value = 'django-watchman-{}'.format(uuid.uuid4())
-    try:
-        cache = get_cache(cache_name)
-        cache.set(key, value)
-        cache.get(key)
-        cache.delete(key)
-        response = {cache_name: {"ok": True}}
-    except Exception as e:
-        response = {
-            cache_name: {
-                "ok": False,
-                "error": str(e),
-                "stacktrace": traceback.format_exc(),
-            },
-        }
-    return response
+
+    cache = get_cache(cache_name)
+    cache.set(key, value)
+    cache.get(key)
+    cache.delete(key)
+    return {cache_name: {"ok": True}}
 
 
 def _check_databases(databases):
     return [_check_database(database) for database in databases]
 
 
+@check
 def _check_database(database):
-    try:
-        connections[database].introspection.table_names()
-        response = {database: {"ok": True}}
-    except Exception as e:
-        response = {
-            database: {
-                "ok": False,
-                "error": str(e),
-                "stacktrace": traceback.format_exc(),
-            },
-        }
-    return response
+    connections[database].introspection.table_names()
+    return {database: {"ok": True}}
 
 
+@check
 def _check_email():
-    try:
-        headers = {"X-DJANGO-WATCHMAN": True}
-        email = EmailMessage(
-            "django-watchman email check",
-            "This is an automated test of the email system.",
-            "watchman@example.com",
-            ["to@example.com"],
-            headers=headers
-        )
-        email.send()
-        response = {"ok": True}
-    except Exception as e:
-        response = {
-            "ok": False,
-            "error": str(e),
-            "stacktrace": traceback.format_exc(),
-        }
-    return response
+    headers = {"X-DJANGO-WATCHMAN": True}
+    email = EmailMessage(
+        "django-watchman email check",
+        "This is an automated test of the email system.",
+        "watchman@example.com",
+        ["to@example.com"],
+        headers=headers
+    )
+    email.send()
+    return {"ok": True}
 
 
+@check
 def _check_storage():
-    try:
-        filename = 'django-watchman-{}.txt'.format(uuid.uuid4())
-        content = 'django-watchman test file'
-        path = default_storage.save(filename, ContentFile(content))
-        default_storage.size(path)
-        default_storage.open(path).read()
-        default_storage.delete(path)
-        response = {"ok": True}
-    except Exception as e:
-        response = {
-            "ok": False,
-            "error": str(e),
-            "stacktrace": traceback.format_exc(),
-        }
-    return response
+    filename = 'django-watchman-{}.txt'.format(uuid.uuid4())
+    content = 'django-watchman test file'
+    path = default_storage.save(filename, ContentFile(content))
+    default_storage.size(path)
+    default_storage.open(path).read()
+    default_storage.delete(path)
+    return {"ok": True}
 
 
 def caches():

--- a/watchman/decorators.py
+++ b/watchman/decorators.py
@@ -2,8 +2,30 @@ from django.http import HttpResponseForbidden
 from django.views.decorators.csrf import csrf_exempt
 
 from functools import wraps
+import traceback
 
 from watchman import settings
+
+
+def check(func):
+    """
+    Decorator which wraps checks and returns an error response on failure.
+    """
+    def wrapped(*args, **kwargs):
+        try:
+            response = func(*args, **kwargs)
+        except Exception as e:
+            response = {
+                "ok": False,
+                "error": str(e),
+                "stacktrace": traceback.format_exc(),
+            }
+            # The check contains several individual checks (e.g., one per
+            # database). Preface the results by name.
+            if args:
+                response = {args[0]: response}
+        return response
+    return wrapped
 
 
 def token_required(view_func):


### PR DESCRIPTION
This commit adds a simple decorator that catches exceptions and
translates them to a `django-watchman` error response.

This makes adding custom checks much friendlier:

    from watchman.decorators import check

    @check
    def my_check():
        return {'ok': True}