### PR TITLE
Update cache check to use django.core.cache.caches dictionary

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,8 @@ from __future__ import unicode_literals
 
 import unittest
 
+import django
+
 from mock import patch
 
 from watchman.utils import get_cache, get_checks
@@ -27,9 +29,9 @@ class TestWatchman(unittest.TestCase):
             self.assertItemsEqual(list1, list2)
 
     @patch('django.core.cache.get_cache')
-    @patch('django.VERSION')
-    def test_get_cache_less_than_django_17(self, version_mock, get_cache_mock):
-        version_mock.return_value = (1, 6, 6, 'final', 0)
+    @patch('watchman.utils.django')
+    def test_get_cache_less_than_django_17(self, django_mock, get_cache_mock):
+        django_mock.VERSION = (1, 6, 6, 'final', 0)
 
         get_cache('foo')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,20 @@ class TestWatchman(unittest.TestCase):
             # Python 2.7
             self.assertItemsEqual(list1, list2)
 
+    @patch('watchman.utils.django_cache')
+    def test_get_cache(self, cache_mock):
+        cache_key = 'my_cache'
+        cache_value = 'i am a cache'
+        cache = {cache_key: cache_value}
+        def getitem(cache_name):
+            return cache[cache_name]
+
+        cache_mock.caches.__getitem__.side_effect = getitem
+
+        result = get_cache(cache_key)
+
+        self.assertEqual(result, cache_value)
+
     @patch('django.core.cache.get_cache')
     @patch('watchman.utils.django')
     def test_get_cache_less_than_django_17(self, django_mock, get_cache_mock):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,9 @@ from __future__ import unicode_literals
 
 import unittest
 
-from watchman.utils import get_checks
+from mock import patch
+
+from watchman.utils import get_cache, get_checks
 
 
 class TestWatchman(unittest.TestCase):
@@ -23,6 +25,15 @@ class TestWatchman(unittest.TestCase):
         except AttributeError:
             # Python 2.7
             self.assertItemsEqual(list1, list2)
+
+    @patch('django.core.cache.get_cache')
+    @patch('django.VERSION')
+    def test_get_cache_less_than_django_17(self, version_mock, get_cache_mock):
+        version_mock.return_value = (1, 6, 6, 'final', 0)
+
+        get_cache('foo')
+
+        get_cache_mock.assert_called_once_with('foo')
 
     def test_get_checks_returns_all_available_checks_by_default(self):
         checks = [check.__name__ for check in get_checks()]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -20,11 +20,10 @@ import unittest
 import django
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.core import cache
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
-from mock import Mock, patch
+from mock import patch
 
 from watchman import checks, views
 
@@ -79,11 +78,10 @@ class TestWatchman(unittest.TestCase):
         self.assertFalse(response['foo']['ok'])
         self.assertIn(response['foo']['error'], expected_error)
 
-    @patch('django.core.cache.get_cache')
-    def test_check_cache_less_than_django_17_uses_get_cache(self, get_cache_mock):
-        django.VERSION = (1, 6, 6, 'final', 0)
-
+    @patch('watchman.utils.get_cache')
+    def test_check_cache_uses_util_get_cache(self, get_cache_mock):
         checks._check_cache('foo')
+
         get_cache_mock.assert_called_once_with('foo')
 
     def test_response_skipped_checks(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -20,10 +20,11 @@ import unittest
 import django
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.core import cache
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
-from mock import patch
+from mock import Mock, patch
 
 from watchman import checks, views
 
@@ -72,10 +73,18 @@ class TestWatchman(unittest.TestCase):
         self.assertEqual(response['foo']['error'], "The connection foo doesn't exist")
 
     def test_check_cache_handles_exception(self):
-        expected_error = "Could not find backend 'foo': Could not find backend 'foo': foo doesn't look like a module path"
+        expected_error = "Could not find config for 'foo' in settings.CACHES"
+
         response = checks._check_cache('foo')
         self.assertFalse(response['foo']['ok'])
         self.assertIn(response['foo']['error'], expected_error)
+
+    @patch('django.core.cache.get_cache')
+    def test_check_cache_less_than_django_17_uses_get_cache(self, get_cache_mock):
+        django.VERSION = (1, 6, 6, 'final', 0)
+
+        checks._check_cache('foo')
+        get_cache_mock.assert_called_once_with('foo')
 
     def test_response_skipped_checks(self):
         expected_checks = ['caches', 'storage', ]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -78,12 +78,6 @@ class TestWatchman(unittest.TestCase):
         self.assertFalse(response['foo']['ok'])
         self.assertIn(response['foo']['error'], expected_error)
 
-    @patch('watchman.utils.get_cache')
-    def test_check_cache_uses_util_get_cache(self, get_cache_mock):
-        checks._check_cache('foo')
-
-        get_cache_mock.assert_called_once_with('foo')
-
     def test_response_skipped_checks(self):
         expected_checks = ['caches', 'storage', ]
         request = RequestFactory().get('/', data={

--- a/watchman/checks.py
+++ b/watchman/checks.py
@@ -3,8 +3,9 @@
 from __future__ import unicode_literals
 
 import uuid
+import django
 from django.conf import settings
-from django.core.cache import get_cache
+from django.core import cache as django_cache
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.core.mail import EmailMessage
@@ -22,7 +23,13 @@ def _check_cache(cache_name):
     key = 'django-watchman-{}'.format(uuid.uuid4())
     value = 'django-watchman-{}'.format(uuid.uuid4())
 
-    cache = get_cache(cache_name)
+    # As of Django 1.7, django.core.cache.caches replaces
+    # django.core.cache.get_cache
+    if django.VERSION < (1, 7):
+        cache = django_cache.get_cache(cache_name)
+    else:
+        cache = django_cache.caches[cache_name]
+
     cache.set(key, value)
     cache.get(key)
     cache.delete(key)

--- a/watchman/checks.py
+++ b/watchman/checks.py
@@ -3,15 +3,14 @@
 from __future__ import unicode_literals
 
 import uuid
-import django
 from django.conf import settings
-from django.core import cache as django_cache
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.core.mail import EmailMessage
 from django.db import connections
 
 from watchman.decorators import check
+from watchman import utils
 
 
 def _check_caches(caches):
@@ -23,12 +22,7 @@ def _check_cache(cache_name):
     key = 'django-watchman-{}'.format(uuid.uuid4())
     value = 'django-watchman-{}'.format(uuid.uuid4())
 
-    # As of Django 1.7, django.core.cache.caches replaces
-    # django.core.cache.get_cache
-    if django.VERSION < (1, 7):
-        cache = django_cache.get_cache(cache_name)
-    else:
-        cache = django_cache.caches[cache_name]
+    cache = utils.get_cache(cache_name)
 
     cache.set(key, value)
     cache.get(key)

--- a/watchman/utils.py
+++ b/watchman/utils.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import django
+from django.core import cache as django_cache
+
 from watchman.settings import WATCHMAN_CHECKS
 
 try:  # try for Django 1.7+ first.
@@ -32,6 +35,15 @@ except ImportError:  # < Django 1.7
                 raise ImproperlyConfigured('%sModule "%s" does not define a "%s" attribute/class' % (
                     error_prefix, module_path, class_name))
             return attr
+
+
+def get_cache(cache_name):
+    # As of Django 1.7, django.core.cache.caches replaces
+    # django.core.cache.get_cache
+    if django.VERSION < (1, 7):
+        return django_cache.get_cache(cache_name)
+    else:
+        return django_cache.caches[cache_name]
 
 
 def get_checks(check_list=None, skip_list=None):


### PR DESCRIPTION
@mwarkentin I did a `pip install -e` on accounting and it seems to work well. I don't have a project with Django >= 1.7 and a cache to test with

Fixes https://github.com/mwarkentin/django-watchman/issues/47