### PR TITLE
Include assets in source tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,7 @@ include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
+include runtests.py
 recursive-include watchman *.html *.png *.gif *js *jpg *jpeg *svg *py
+recursive-include tests *.py
+recursive-include docs Makefile conf.py *.rst


### PR DESCRIPTION
It is nice to have documentation and tests in the source tarball for creating
distribution packages (e.g. for Debian).