### PR TITLE
Replace django-jsonview with built-in JsonResponse.

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 django
-django-jsonview==0.5.0
 
 coverage
 coveralls

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'django',
-        'django-jsonview>=0.5.0',
     ],
     license="BSD",
     zip_safe=False,


### PR DESCRIPTION
This is just a proposal to remove the dependency on django-jsonview. It is only used for a single view, namely `status`. Using `JsonResponse` set the minimal required version for Django to 1.7.
