### PR TITLE
Fix #73: Parse token from `Authorization` header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,10 @@ your settings. When this setting is added, you must pass that value in as the
 
     GET http://127.0.0.1:8000/watchman/?watchman-token=:token
 
+Or by setting the ``Authorization: WATCHMAN-TOKEN`` header on the request::
+
+    curl -X GET -H "Authorization: WATCHMAN-TOKEN Token=\":token\"" http://127.0.0.1:8000/watchman/
+
 If you want to change the token name, you can set the ``WATCHMAN_TOKEN_NAME``.
 The value of this setting will be the **GET** parameter that you must pass in::
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -135,7 +135,7 @@ class TestWatchman(unittest.TestCase):
 
     @override_settings(WATCHMAN_TOKEN='ABCDE')
     @override_settings(WATCHMAN_AUTH_DECORATOR='watchman.decorators.token_required')
-    def test_login_not_required(self):
+    def test_login_not_required_with_get_param(self):
         # Have to manually reload settings here because override_settings
         # happens after self.setUp(), but before self.tearDown()
         reload_settings()
@@ -146,6 +146,40 @@ class TestWatchman(unittest.TestCase):
         response = views.status(request)
 
         self.assertEqual(response.status_code, 200)
+
+    @override_settings(WATCHMAN_TOKEN='ABCDE')
+    @override_settings(WATCHMAN_AUTH_DECORATOR='watchman.decorators.token_required')
+    def test_login_not_required_with_authorization_header(self):
+        # Have to manually reload settings here because override_settings
+        # happens after self.setUp(), but before self.tearDown()
+        reload_settings()
+        request = RequestFactory().get('/', HTTP_AUTHORIZATION='WATCHMAN-TOKEN Token="ABCDE"')
+        response = views.status(request)
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(WATCHMAN_TOKEN='ABCDE')
+    @override_settings(WATCHMAN_AUTH_DECORATOR='watchman.decorators.token_required')
+    def test_login_fails_with_invalid_get_param(self):
+        # Have to manually reload settings here because override_settings
+        # happens after self.setUp(), but before self.tearDown()
+        reload_settings()
+        request = RequestFactory().get('/', data={
+            'watchman-token': '12345',
+        })
+
+        response = views.status(request)
+
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(WATCHMAN_TOKEN='ABCDE')
+    @override_settings(WATCHMAN_AUTH_DECORATOR='watchman.decorators.token_required')
+    def test_login_fails_with_invalid_authorization_header(self):
+        # Have to manually reload settings here because override_settings
+        # happens after self.setUp(), but before self.tearDown()
+        reload_settings()
+        request = RequestFactory().get('/', HTTP_AUTHORIZATION='WATCHMAN-TOKEN Token="12345"')
+        response = views.status(request)
+        self.assertEqual(response.status_code, 403)
 
     @override_settings(WATCHMAN_AUTH_DECORATOR='django.contrib.auth.decorators.login_required')
     def test_response_when_login_required_is_redirect(self):


### PR DESCRIPTION
Start by trying to get the token from the header, fall back to the `GET` param.

Expected format: `Authorization: WATCHMAN-TOKEN Token="ABC123"`

### Todo

* [x] Add tests
* [x] Update docs