### PR TITLE
Fix #78: Email check settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Quickstart
         ],
         "storage": {"ok": true}
     }
-    
+
 Pycon Canada Presentation (10 minutes)
 --------------------------------------
 
@@ -223,6 +223,11 @@ this check is **not enabled** by default.
 
 For reference, if you were using Mandrill, and hitting your watchman endpoint
 once per minute, this would cost you ~$5.60/month.
+
+**Custom Settings**
+
+* ``WATCHMAN_EMAIL_RECIPIENTS`` (default: ``[to@example.com]``): Specify a list of email addresses to send the test email
+* ``WATCHMAN_EMAIL_HEADERS`` (default: ``{}``): Specify a dict of custom headers to be added to the test email
 
 storage
 *******

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -234,12 +234,46 @@ class TestWatchmanDashboard(unittest.TestCase):
         self.assertTrue(response.has_header('X-Watchman-Version'))
 
 
+# TODO: Figure out why settings defaults aren't working - related to https://github.com/mwarkentin/django-watchman/issues/13?
+@override_settings(WATCHMAN_EMAIL_RECIPIENTS=['to@example.com'])
+@override_settings(WATCHMAN_EMAIL_HEADERS={})
 class TestEmailCheck(DjangoTestCase):
     def setUp(self):
         # Ensure that every test executes with separate settings
         reload_settings()
 
-    @override_settings(WATCHMAN_EMAIL_HEADERS={})
+    def def_test_email_with_default_recipient(self):
+        checks._check_email()
+
+        # Test that one message has been sent.
+        self.assertEqual(len(mail.outbox), 1)
+
+        sent_email = mail.outbox[0]
+        expected_recipients = ['to@example.com']
+        self.assertEqual(sent_email.to, expected_recipients)
+
+    @override_settings(WATCHMAN_EMAIL_RECIPIENTS=['custom@example.com'])
+    def def_test_email_with_custom_recipient(self):
+        checks._check_email()
+
+        # Test that one message has been sent.
+        self.assertEqual(len(mail.outbox), 1)
+
+        sent_email = mail.outbox[0]
+        expected_recipients = ['custom@example.com']
+        self.assertEqual(sent_email.to, expected_recipients)
+
+    @override_settings(WATCHMAN_EMAIL_RECIPIENTS=['to1@example.com', 'to2@example.com'])
+    def def_test_email_with_multiple_recipients(self):
+        checks._check_email()
+
+        # Test that one message has been sent.
+        self.assertEqual(len(mail.outbox), 1)
+
+        sent_email = mail.outbox[0]
+        expected_recipients = ['to1@example.com', 'to2@example.com']
+        self.assertEqual(sent_email.to, expected_recipients)
+
     def test_email_check_with_default_headers(self):
         checks._check_email()
 

--- a/watchman/checks.py
+++ b/watchman/checks.py
@@ -48,8 +48,8 @@ def _check_email():
         "django-watchman email check",
         "This is an automated test of the email system.",
         "watchman@example.com",
-        ["to@example.com"],
-        headers=headers
+        settings.WATCHMAN_EMAIL_RECIPIENTS,
+        headers=headers,
     )
     email.send()
     return {"ok": True}

--- a/watchman/checks.py
+++ b/watchman/checks.py
@@ -43,6 +43,7 @@ def _check_database(database):
 @check
 def _check_email():
     headers = {"X-DJANGO-WATCHMAN": True}
+    headers.update(settings.WATCHMAN_EMAIL_HEADERS)
     email = EmailMessage(
         "django-watchman email check",
         "This is an automated test of the email system.",

--- a/watchman/settings.py
+++ b/watchman/settings.py
@@ -6,6 +6,7 @@ WATCHMAN_AUTH_DECORATOR = getattr(settings, 'WATCHMAN_AUTH_DECORATOR', 'watchman
 WATCHMAN_TOKEN = getattr(settings, 'WATCHMAN_TOKEN', None)
 WATCHMAN_TOKEN_NAME = getattr(settings, 'WATCHMAN_TOKEN_NAME', 'watchman-token')
 WATCHMAN_ERROR_CODE = getattr(settings, 'WATCHMAN_ERROR_CODE', 500)
+WATCHMAN_EMAIL_RECIPIENTS = getattr(settings, 'WATCHMAN_EMAIL_RECIPIENTS', ['to@example.com'])
 WATCHMAN_EMAIL_HEADERS = getattr(settings, 'WATCHMAN_EMAIL_HEADERS', {})
 
 DEFAULT_CHECKS = (

--- a/watchman/settings.py
+++ b/watchman/settings.py
@@ -6,6 +6,7 @@ WATCHMAN_AUTH_DECORATOR = getattr(settings, 'WATCHMAN_AUTH_DECORATOR', 'watchman
 WATCHMAN_TOKEN = getattr(settings, 'WATCHMAN_TOKEN', None)
 WATCHMAN_TOKEN_NAME = getattr(settings, 'WATCHMAN_TOKEN_NAME', 'watchman-token')
 WATCHMAN_ERROR_CODE = getattr(settings, 'WATCHMAN_ERROR_CODE', 500)
+WATCHMAN_EMAIL_HEADERS = getattr(settings, 'WATCHMAN_EMAIL_HEADERS', {})
 
 DEFAULT_CHECKS = (
     'watchman.checks.caches',

--- a/watchman/settings.py
+++ b/watchman/settings.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-# TODO: these should not be module level.
+# TODO: these should not be module level (https://github.com/mwarkentin/django-watchman/issues/13)
 WATCHMAN_ENABLE_PAID_CHECKS = getattr(settings, 'WATCHMAN_ENABLE_PAID_CHECKS', False)
 WATCHMAN_AUTH_DECORATOR = getattr(settings, 'WATCHMAN_AUTH_DECORATOR', 'watchman.decorators.token_required')
 WATCHMAN_TOKEN = getattr(settings, 'WATCHMAN_TOKEN', None)


### PR DESCRIPTION
* Add `WATCHMAN_EMAIL_HEADERS` setting
* Add `WATCHMAN_EMAIL_RECIPIENTS` setting
* Merge headers before sending email

### TODO

* [x] Tests
* [x] Update docs