### PR TITLE
Fix tests for Django cache version

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from __future__ import unicode_literals
 
 import unittest
 
+import django
 from mock import patch
 
 from watchman.utils import get_cache, get_checks
@@ -41,14 +42,13 @@ class TestWatchman(unittest.TestCase):
 
         self.assertEqual(result, cache_value)
 
-    @unittest.skip("Seems to be blowing up on Django 1.9")
+    @unittest.skipIf(
+        django.VERSION >= (1, 7),
+        'get_cache has been deprecated as of Django 1.7'
+    )
     @patch('django.core.cache.get_cache')
-    @patch('watchman.utils.django')
-    def test_get_cache_less_than_django_17(self, django_mock, get_cache_mock):
-        django_mock.VERSION = (1, 6, 6, 'final', 0)
-
+    def test_get_cache_less_than_django_17(self, get_cache_mock):
         get_cache('foo')
-
         get_cache_mock.assert_called_once_with('foo')
 
     def test_get_checks_returns_all_available_checks_by_default(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,20 +27,14 @@ class TestWatchman(unittest.TestCase):
             # Python 2.7
             self.assertItemsEqual(list1, list2)
 
-    @patch('watchman.utils.django_cache')
-    def test_get_cache(self, cache_mock):
-        cache_key = 'my_cache'
-        cache_value = 'i am a cache'
-        cache = {cache_key: cache_value}
-
-        def getitem(cache_name):
-            return cache[cache_name]
-
-        cache_mock.caches.__getitem__.side_effect = getitem
-
-        result = get_cache(cache_key)
-
-        self.assertEqual(result, cache_value)
+    @unittest.skipIf(
+        django.VERSION < (1, 7),
+        'caches interface is not added until Django 1.7',
+    )
+    @patch('watchman.utils.django_cache.caches', spec_set=dict)
+    def test_get_cache_django_17_or_greater(self, get_cache_mock):
+        get_cache('foo')
+        get_cache_mock.__getitem__.called_once_with('foo')
 
     @unittest.skipIf(
         django.VERSION >= (1, 7),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -74,7 +74,10 @@ class TestWatchman(unittest.TestCase):
         self.assertEqual(response['foo']['error'], "The connection foo doesn't exist")
 
     def test_check_cache_handles_exception(self):
-        expected_error = "Could not find config for 'foo' in settings.CACHES"
+        if django.VERSION < (1, 7):
+            expected_error = "Could not find backend 'foo': Could not find backend 'foo': foo doesn't look like a module path"
+        else:
+            expected_error = "Could not find config for 'foo' in settings.CACHES"
 
         response = checks._check_cache('foo')
         self.assertFalse(response['foo']['ok'])


### PR DESCRIPTION
Fixes #70 

In Django v1.7 the cache interface changed from the `django.core.cache.get_cache` method to a `django.core.cache.caches` dict-like object. Watchman's `utils.get_cache` provides some convenience in wrapping this change and doing The Right Thing™ but some of the tests were breaking when run against earlier versions of Django.

The tests have been updated, and simplified where necessary. 