### PR TITLE
Fix 500 errors with ATOMIC_REQUESTS enabled (#85)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,27 @@ language: python
 
 python:
   - "2.7"
+  - "3.4"
   - "3.5"
 
 env:
-  - DJANGO_VERSION=1.7.11
-  - DJANGO_VERSION=1.8.7
-  - DJANGO_VERSION=1.9.0
+  matrix:
+    - DJANGO_VERSION=dj17
+    - DJANGO_VERSION=dj18
+    - DJANGO_VERSION=dj19
+    - DJANGO_VERSION=dj110
 
 matrix:
   exclude:
     - python: "3.5"
-      env: DJANGO_VERSION=1.7.11
+      env: DJANGO_VERSION=dj17
 
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - pip install -r requirements-test.txt
-  - pip install Django==$DJANGO_VERSION
+  - pip install tox
 
 # command to run tests using coverage, e.g. python setup.py test
-script: coverage run --source watchman runtests.py
+script:
+  - tox -e py${TRAVIS_PYTHON_VERSION//./}-${DJANGO_VERSION},coverage
 
 # report coverage to coveralls.io
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-# Config file for automatic testing at travis-ci.org
-
+sudo: false
 language: python
 
 python:
@@ -9,22 +8,22 @@ python:
 
 env:
   matrix:
-    - DJANGO_VERSION=dj17
-    - DJANGO_VERSION=dj18
-    - DJANGO_VERSION=dj19
-    - DJANGO_VERSION=dj110
+    - DJANGO_VERSION=1.7
+    - DJANGO_VERSION=1.8
+    - DJANGO_VERSION=1.9
+    - DJANGO_VERSION=1.10
 
 matrix:
   exclude:
     - python: "3.5"
-      env: DJANGO_VERSION=dj17
+      env: DJANGO_VERSION=1.7
 
 install:
-  - pip install tox
+  - pip install tox coveralls
 
 # command to run tests using coverage, e.g. python setup.py test
 script:
-  - tox -e py${TRAVIS_PYTHON_VERSION//./}-${DJANGO_VERSION},coverage
+  - tox -e py${TRAVIS_PYTHON_VERSION//./}-dj${DJANGO_VERSION//./},coverage
 
 # report coverage to coveralls.io
 after_success: coveralls

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,10 +1,11 @@
 django-jsonview==0.5.0
 
 coverage>=4.0
-coveralls
 mock>=1.0.1
 nose>=1.3.0
 django-nose>=1.2
 flake8>=2.1.0
 restructuredtext_lint==0.12.2
+# We use PyMySQL because it's pure python, has no C dependencies and can emulate MySQLDb
+PyMySQL>=0.7.5
 tox>=1.7.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,6 @@
-django
 django-jsonview==0.5.0
 
-coverage
+coverage>=4.0
 coveralls
 mock>=1.0.1
 nose>=1.3.0

--- a/runtests.py
+++ b/runtests.py
@@ -9,8 +9,14 @@ try:
         DATABASES={
             "default": {
                 "ENGINE": "django.db.backends.sqlite3",
-            }
+            },
         },
+        TEMPLATES=[
+            {
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'APP_DIRS': True,
+            },
+        ],
         ROOT_URLCONF="watchman.urls",
         INSTALLED_APPS=[
             "django.contrib.auth",

--- a/runtests.py
+++ b/runtests.py
@@ -1,4 +1,6 @@
 import sys
+import traceback
+
 
 try:
     from django.conf import settings
@@ -30,7 +32,8 @@ try:
 
     from django_nose import NoseTestSuiteRunner
 except ImportError:
-    raise ImportError("To fix this error, run: pip install -r requirements-test.txt")
+    traceback.print_exc()
+    raise RuntimeError("To fix this error, run: pip install django -r requirements-test.txt")
 
 
 def run_tests(*test_args):

--- a/runtests.py
+++ b/runtests.py
@@ -5,6 +5,10 @@ import traceback
 try:
     from django.conf import settings
 
+    from pymysql import install_as_MySQLdb
+
+    install_as_MySQLdb()
+
     settings.configure(
         DEBUG=True,
         USE_TZ=True,

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -11,7 +11,10 @@ from __future__ import unicode_literals
 
 import unittest
 
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.test.client import Client
 
 import mock
@@ -33,7 +36,7 @@ class TestWatchman(unittest.TestCase):
 
     def test_200_ok_if_no_token_set(self):
         watchman_settings.WATCHMAN_TOKEN = None
-        response = self.client.get(reverse('watchman.views.status'))
+        response = self.client.get(reverse('status'))
         self.assertEqual(response.status_code, 200)
         watchman_settings.WATCHMAN_TOKEN = 'foo'
 
@@ -41,7 +44,7 @@ class TestWatchman(unittest.TestCase):
         data = {
             'watchman-token': 'foo',
         }
-        response = self.client.get(reverse('watchman.views.status'), data)
+        response = self.client.get(reverse('status'), data)
         self.assertEqual(response.status_code, 200)
 
     def test_required_token_param_can_be_renamed(self):
@@ -49,19 +52,19 @@ class TestWatchman(unittest.TestCase):
         data = {
             'custom-token': 'foo',
         }
-        response = self.client.get(reverse('watchman.views.status'), data)
+        response = self.client.get(reverse('status'), data)
         self.assertEqual(response.status_code, 200)
         watchman_settings.WATCHMAN_TOKEN_NAME = 'watchman-token'
 
     def test_403_raised_if_missing_token(self):
-        response = self.client.get(reverse('watchman.views.status'))
+        response = self.client.get(reverse('status'))
         self.assertEqual(response.status_code, 403)
 
     def test_403_raised_if_invalid_token(self):
         data = {
             'watchman-token': 'bar',
         }
-        response = self.client.get(reverse('watchman.views.status'), data)
+        response = self.client.get(reverse('status'), data)
         self.assertEqual(response.status_code, 403)
 
     # We cannot easily mock a stacktrace, since:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -31,6 +31,22 @@ from watchman import checks, views
 
 PYTHON_VERSION = sys.version_info[0]
 
+
+class AuthenticatedUser(AnonymousUser):
+    @property
+    def is_authenticated(self):
+        class CallableTrue(object):
+            def __call__(self, *args, **kwargs):
+                return True
+
+            def __bool__(self):
+                return True
+
+            __nonzero__ = __bool__
+
+        return CallableTrue()
+
+
 if django.VERSION >= (1, 7):
     # Initialize Django
     django.setup()
@@ -214,9 +230,7 @@ class TestWatchman(unittest.TestCase):
         # happens after self.setUp()
         reload_settings()
         request = RequestFactory().get('/')
-        request.user = AnonymousUser()
-        # Fake logging the user in
-        request.user.is_authenticated = lambda: True
+        request.user = AuthenticatedUser()
 
         response = views.status(request)
         self.assertEqual(response.status_code, 200)

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,29 @@
 [tox]
-envlist = py27, py34
+envlist =
+    covclean,
+    py{27,34}-dj{17,18,19,110},
+    py35-dj{18,19,110},
+    coverage
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/watchman
-commands = python runtests.py
+commands = coverage run --parallel --source watchman runtests.py {posargs}
 deps =
+    dj17: Django>=1.7,<1.8
+    dj18: Django>=1.8,<1.9
+    dj19: Django>=1.9,<1.10
+    dj110: Django==1.10rc1
     -r{toxinidir}/requirements-test.txt
+
+[testenv:covclean]
+skip_install=True
+deps = coverage>=4.0
+commands = coverage erase
+
+[testenv:coverage]
+skip_install=True
+deps = coverage>=4.0
+commands =
+    coverage combine
+    coverage report --show-missing

--- a/watchman/management/commands/watchman.py
+++ b/watchman/management/commands/watchman.py
@@ -8,23 +8,33 @@ from django.core.management.base import BaseCommand, CommandError
 from watchman.utils import get_checks
 
 
-class Command(BaseCommand):
-    help = 'Runs the default django-watchman checks'
-
-    option_list = BaseCommand.option_list + (
-        make_option(
+def _add_options(target):
+    return (
+        target(
             '-c',
             '--checks',
             dest='checks',
             help='A comma-separated list of watchman checks to run (full python dotted paths)'
         ),
-        make_option(
+        target(
             '-s',
             '--skips',
             dest='skips',
             help='A comma-separated list of watchman checks to skip (full python dotted paths)'
-        ),
+        )
     )
+
+
+class Command(BaseCommand):
+    help = 'Runs the default django-watchman checks'
+
+    if hasattr(BaseCommand, 'option_list'):
+        # Django < 1.10
+        option_list = BaseCommand.option_list + _add_options(make_option)
+    else:
+        # Django >= 1.10
+        def add_arguments(self, parser):
+            _add_options(parser.add_argument)
 
     def handle(self, *args, **options):
         check_list = None

--- a/watchman/views.py
+++ b/watchman/views.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+from django.db.transaction import non_atomic_requests
 from django.http import Http404
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
@@ -30,6 +31,7 @@ def _get_check_params(request):
 
 @auth
 @json_view
+@non_atomic_requests
 def status(request):
     response = {}
     http_code = 200
@@ -60,6 +62,7 @@ def status(request):
 
 
 @auth
+@non_atomic_requests
 def dashboard(request):
     check_types = []
 


### PR DESCRIPTION
This PR fixes #85 

Along the way I also fixed the few Django 1.10 incompatibilities and updated the tox config to also locally test against Django 1.7 - 1.10. Also travis now uses tox to run the tests so there is no duplication. I hope you don't mind.

The fix itself is in the last commit (0690f8d). Without it the one new test (introduced in the commit before, f75e717) will fail.