### PR TITLE
Restructure the dashboard a bit and update it to use FontAwesome instead of Glyphicon

### DIFF
--- a/watchman/templates/watchman/base.html
+++ b/watchman/templates/watchman/base.html
@@ -1,21 +1,24 @@
-
-{% comment %}
-As the developer of this package, don't place anything here if you can help it
-since this allows developers to have interoperability between your template
-structure and their own.
-
-Example: Developer melding the 2SoD pattern to fit inside with another pattern::
-
-    {% extends "base.html" %}
-    {% load static %}
-
-    <!-- Their site uses old school block layout -->
-    {% block extra_js %}
-
-        <!-- Your package using 2SoD block layout -->
-        {% block javascript %}
-            <script src="{% static 'js/ninja.js' %}" type="text/javascript"></script>
-        {% endblock javascript %}
-
-    {% endblock extra_js %}
-{% endcomment %}
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+        <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
+        <style>
+        @media (min-width: 768px) {
+        .modal-dialog {
+            width: auto;
+            margin: 30px 30px;
+        }
+        }
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            {% block content %}
+            {% endblock %}{# content #}
+        </div><!-- .container -->
+    </body>
+</html>

--- a/watchman/templates/watchman/base.html
+++ b/watchman/templates/watchman/base.html
@@ -2,9 +2,9 @@
 <html lang="en">
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
         <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
         <style>
         @media (min-width: 768px) {

--- a/watchman/templates/watchman/dashboard.html
+++ b/watchman/templates/watchman/dashboard.html
@@ -1,87 +1,111 @@
+{% extends "watchman/base.html" %}
+
 {% load i18n %}
 
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-        <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-    </head>
-    <body>
-        {% block content %}
-        <div class="container">
-            <h2>{% trans 'System Status' %}</h2>
-            <h3 class="{% if overall_status %}text-success{% else %}text-danger{% endif %}">
+{% block content %}
+{% block status_content %}
+<div class="row">
+    <div class="col-xs-12 col-sm-offset-1 col-sm-10 col-md-offset-2 col-md-8 col-lg-offset-3 col-lg-6">
+        <h2>
+            {% trans "System Status" %}
+
+            <span class="{% if overall_status %}text-success{% else %}text-danger{% endif %} pull-right">
                 {% if overall_status %}
-                    <span class="glyphicon glyphicon-ok"></span> {% trans 'All systems up and running!' %}
+                <i class="fa fa-check"></i> {% trans "OK" %}
                 {% else %}
-                    <span class="glyphicon glyphicon-alert"></span> {% trans 'WARNING - Some systems down!' %}
+                <i class="fa fa-exclamation-triangle"></i> {% trans "WARNING" %}
                 {% endif %}{# overall_status #}
-            </h3>
-            <small></small>
+            </span>
+        </h2>
+    </div><!-- .col -->
+</div><!-- .row -->
 
-            <table class="table table-bordered table-hover">
-                <thead>
-                <tr>
-                    <th>{% trans 'Type' %}</th>
-                    <th>{% trans 'Name' %}</th>
-                    <th>{% trans 'Status' %}</th>
-                </tr>
-                </thead>
-                <tbody>
-                {% for type in checks %}
-                {% for status in type.statuses %}
-                <tr class="{% if type.ok %}success{% else %}danger{% endif %}">
-                    <td>{{ type.type|title }}</td>
-                    <td>{{ status.name|title }}</td>
+<div class="row">
+    <div class="col-xs-12 col-sm-offset-1 col-sm-10 col-md-offset-2 col-md-8 col-lg-offset-3 col-lg-6">
+        <h3 class="{% if overall_status %}text-success{% else %}text-danger{% endif %}">
+            {% if overall_status %}
+            {% trans "All systems go!" %}
+            {% else %}
+            {% trans "Some systems down!" %}
+            {% endif %}{# overall_status #}
+        </h3>
+        <small></small>
+    </div><!-- .col -->
+</div><!-- .row -->
 
-                    {% if status.ok %}
-                    <td class="success">{% trans 'OK' %}</td>
+<div class="row">
+    <div class="col-xs-12 col-sm-offset-1 col-sm-10 col-md-offset-2 col-md-8 col-lg-offset-3 col-lg-6">
+        <hr />
+    </div><!-- .col -->
+</div><!-- .row -->
 
-                    {% else %}
-                    <td class="danger">
-                        <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#{{ type.type }}{% if status.name %}-{{ status.name }}{% endif %}">{% trans 'ERROR!' %}</button>
-                    </td>
-                    {% endif %}{# status.ok #}
+<div class="row">
+    <div class="col-xs-12 col-sm-offset-1 col-sm-10 col-md-offset-2 col-md-8 col-lg-offset-3 col-lg-6">
+        <table class="table table-bordered table-hover">
+            <thead>
+            <tr>
+                <th>{% trans "Type" %}</th>
+                <th>{% trans "Name" %}</th>
+                <th>{% trans "Status" %}</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for type in checks %}
+            {% for status in type.statuses %}
+            <tr>
+                <td class="{% if type.ok %}success{% else %}{% if not status.ok %}danger{% else %}warning{% endif %}{# not status.ok #}{% endif %}{# type.ok #}">{{ type.type_singular|title }}</td>
+                <td class="{% if status.ok %}success{% else %}danger{% endif %}">{{ status.name }}</td>
 
-                </tr>
-                {% endfor %}{# for status in type.statuses #}
-                {% empty %}
-                <tr>
-                    <td colspan="3">{% trans 'No checks indicated.' %}</td>
-                </tr>
-                {% endfor %}{# for type in checks #}
-                </tbody>
-            </table>
+                {% if status.ok %}
+                <td class="success">{% trans "OK" %}</td>
 
-            {% if not overall_status %}<span class="pull-right"><small>{% trans 'Click an error button to see the full traceback' %}</small></span>{% endif %}{# overall_status #}
-        </div>
-        {% endblock %}{# status_content #}
+                {% else %}
+                <td class="danger">
+                    {% trans "ERROR!" %}
+
+                    <div class="btn-group btn-group-xs pull-right">
+                        <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#{{ type.type }}{% if status.name %}-{{ status.name }}{% endif %}">{% trans "Traceback" %}</button>
+                    </div>
+                </td>
+                {% endif %}{# status.ok #}
+
+            </tr>
+            {% endfor %}{# for status in type.statuses #}
+            {% empty %}
+            <tr>
+                <td colspan="3">{% trans "No checks indicated." %}</td>
+            </tr>
+            {% endfor %}{# for type in checks #}
+            </tbody>
+        </table>
+    </div><!-- .col -->
+</div><!-- .row -->
+{% endblock %}{# status_content #}
 
 
-        {% for type in checks %}
-        {% for status in type.statuses %}
-        {% if not status.ok %}
-        <div class="modal fade" id="{{ type.type }}{% if status.name %}-{{ status.name }}{% endif %}" tabindex="-1" role="dialog" aria-labelledby="{{ type.type }}{% if status.name %}-{{ status.name }}{% endif %}-title">
-            <div class="modal-dialog" role="document" style="width: 65%">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title" id="{{ type.type }}{% if status.name %}-{{ status.name }}{% endif %}-title">{{ type.type|title }}{% if status.name %} - {{ status.name|title }}{% endif %}</h4>
-                    </div><!-- class="modal-header" -->
-                    <div class="modal-body">
-                        <h4><pre>{{ status.error }}</pre></h4>
-                        <pre>{{ status.stacktrace }}</pre>
-                    </div><!-- class="model-body" -->
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                    </div><!-- class="modal-footer" -->
-                </div><!-- class="modal-content" -->
-            </div><!-- class="modal-dialog" -->
-        </div><!-- class="modal fade" -->
-        {% endif %}{# not status.ok #}
-        {% endfor %}{# for type in checks #}
-        {% endfor %}{# for status in type.statuses #}
-    </body>
-</html>
+{% block error_content %}
+{% for type in checks %}
+{% for status in type.statuses %}
+{% if not status.ok %}
+<div class="modal fade" id="{{ type.type }}{% if status.name %}-{{ status.name }}{% endif %}" tabindex="-1" role="dialog" aria-labelledby="{{ type.type }}{% if status.name %}-{{ status.name }}{% endif %}-title">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="{{ type.type }}{% if status.name %}-{{ status.name }}{% endif %}-title">{{ type.type|title }}{% if status.name %} - {{ status.name|title }}{% endif %}</h4>
+            </div><!-- class="modal-header" -->
+            <div class="modal-body">
+                <h4><pre>{{ status.error }}</pre></h4>
+                <pre>{{ status.stacktrace }}</pre>
+            </div><!-- class="model-body" -->
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div><!-- class="modal-footer" -->
+        </div><!-- class="modal-content" -->
+    </div><!-- class="modal-dialog" -->
+</div><!-- class="modal fade" -->
+{% endif %}{# not status.ok #}
+{% endfor %}{# for type in checks #}
+{% endfor %}{# for status in type.statuses #}
+{% endblock %}{# error_content #}
+{% endblock %}{# content #}

--- a/watchman/views.py
+++ b/watchman/views.py
@@ -131,6 +131,7 @@ def dashboard(request):
 
                 check_types.append({
                     'type': _type,
+                    'type_singular': _type[:-1] if _type.endswith('s') else _type,
                     'ok': type_overall_status,
                     'statuses': statuses})
 


### PR DESCRIPTION
I tweaked the look of the dashboard. The black boxes are just to keep my internal names out of the public record.

Additionally, I filled out `watchman/base.html` with basic HTML that should more closely mimic an actual site's `base.html`, and had `watchman/dashboard.html` extend from that. That way it should be easier to embed the dashboard in an existing site that uses Bootstrap components (by just overwriting `watchman/base.html`).

~~The only logic change that could affect anything else is I changed the check names to be singular instead of plural. I haven't tested that part yet.~~
Travis tested it for me. It broke stuff. So now I just strip off the 's' at the end of plural type names and stuff it into `type_singular` for the template.

Status: OK
----------

The overall system status is now on the upper right with a FontAwesome icon (instead of Glyphicon because Bootstrap is moving to FontAwesome).

![watchman-status-ok](https://cloud.githubusercontent.com/assets/597113/17234903/1493583c-54fa-11e6-8176-a0e4e1a6c50b.png)

Status: Error
-------------

I separated the error text and the button for tracebacks so I could get rid of the explanatory text at the bottom. I figure if an interface/widget needs explanatory text it's probably not that great to begin with. This way everything is more direct and explicit (click "Traceback" to get a traceback, status text is just text, not a button).

Also, if not all subsystems of a specific type are all up, they **all** get a yellow background except for the subsystem that is down. That is more confusing in words, the picture should explain enough.

![watchman-status-error](https://cloud.githubusercontent.com/assets/597113/17234908/1fa373b0-54fa-11e6-9211-3d52e39c3b55.png)

Traceback
---------

I tweaked the traceback so its width auto-expands to fill the whole window for all screen sizes (margins are 10px - Bootstrap's default - when the screen is <= 768px wide and 30px otherwise).

![watchman-traceback](https://cloud.githubusercontent.com/assets/597113/17234912/2638e91c-54fa-11e6-8d2b-f5005c94ea86.png)
