### PR TITLE
Fix #86: Support multiple auth tokens

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,9 +79,9 @@ Features
 Token based authentication
 **************************
 
-If you want to protect the status endpoint, you can add a ``WATCHMAN_TOKEN`` to
-your settings. When this setting is added, you must pass that value in as the
-``watchman-token`` **GET** parameter::
+If you want to protect the status endpoint, you can use the ``WATCHMAN_TOKENS`` setting.
+This is a comma-separated list of tokens.
+When this setting is added, you must pass one of the tokens in as the ``watchman-token`` **GET** parameter::
 
     GET http://127.0.0.1:8000/watchman/?watchman-token=:token
 
@@ -95,6 +95,9 @@ The value of this setting will be the **GET** parameter that you must pass in::
     WATCHMAN_TOKEN_NAME = 'custom-token-name'
 
     GET http://127.0.0.1:8000/watchman/?custom-token-name=:token
+
+**DEPRECATION WARNING**: ``WATCHMAN_TOKEN`` was replaced by the ``WATCHMAN_TOKENS`` setting to support multiple authentication tokens in django-watchman ``0.11``.
+It will continue to work until it's removed in django-watchman ``1.0``.
 
 Custom authentication/authorization
 ***********************************

--- a/watchman/decorators.py
+++ b/watchman/decorators.py
@@ -31,7 +31,7 @@ def check(func):
 
 def token_required(view_func):
     """
-    Decorator which ensures that WATCHMAN_TOKEN is provided if set.
+    Decorator which ensures that one of the WATCHMAN_TOKENS is provided if set.
 
     WATCHMAN_TOKEN_NAME can also be set if the token GET parameter must be
     customized.
@@ -66,14 +66,19 @@ def token_required(view_func):
         return token
 
     def _validate_token(request):
-        watchman_token = settings.WATCHMAN_TOKEN
+        if settings.WATCHMAN_TOKENS:
+            watchman_tokens = settings.WATCHMAN_TOKENS.split(',')
+        elif settings.WATCHMAN_TOKEN:
+            watchman_tokens = [settings.WATCHMAN_TOKEN, ]
+        else:
+            watchman_tokens = []
 
-        if watchman_token is None:
+        if not watchman_tokens:
             return True
 
         passed_token = _get_passed_token(request)
 
-        return watchman_token == passed_token
+        return passed_token in watchman_tokens
 
     @csrf_exempt
     @wraps(view_func)

--- a/watchman/decorators.py
+++ b/watchman/decorators.py
@@ -71,9 +71,9 @@ def token_required(view_func):
         elif settings.WATCHMAN_TOKEN:
             watchman_tokens = [settings.WATCHMAN_TOKEN, ]
         else:
-            watchman_tokens = []
+            watchman_tokens = None
 
-        if not watchman_tokens:
+        if watchman_tokens is None:
             return True
 
         passed_token = _get_passed_token(request)

--- a/watchman/decorators.py
+++ b/watchman/decorators.py
@@ -71,14 +71,9 @@ def token_required(view_func):
         elif settings.WATCHMAN_TOKEN:
             watchman_tokens = [settings.WATCHMAN_TOKEN, ]
         else:
-            watchman_tokens = None
-
-        if watchman_tokens is None:
             return True
 
-        passed_token = _get_passed_token(request)
-
-        return passed_token in watchman_tokens
+        return _get_passed_token(request) in watchman_tokens
 
     @csrf_exempt
     @wraps(view_func)

--- a/watchman/settings.py
+++ b/watchman/settings.py
@@ -3,6 +3,7 @@ from django.conf import settings
 # TODO: these should not be module level (https://github.com/mwarkentin/django-watchman/issues/13)
 WATCHMAN_ENABLE_PAID_CHECKS = getattr(settings, 'WATCHMAN_ENABLE_PAID_CHECKS', False)
 WATCHMAN_AUTH_DECORATOR = getattr(settings, 'WATCHMAN_AUTH_DECORATOR', 'watchman.decorators.token_required')
+# TODO: Remove for django-watchman 1.0
 WATCHMAN_TOKEN = getattr(settings, 'WATCHMAN_TOKEN', None)
 WATCHMAN_TOKENS = getattr(settings, 'WATCHMAN_TOKENS', None)
 WATCHMAN_TOKEN_NAME = getattr(settings, 'WATCHMAN_TOKEN_NAME', 'watchman-token')

--- a/watchman/settings.py
+++ b/watchman/settings.py
@@ -1,5 +1,3 @@
-import warnings
-
 from django.conf import settings
 
 # TODO: these should not be module level (https://github.com/mwarkentin/django-watchman/issues/13)
@@ -25,6 +23,3 @@ if WATCHMAN_ENABLE_PAID_CHECKS:
     DEFAULT_CHECKS = DEFAULT_CHECKS + PAID_CHECKS
 
 WATCHMAN_CHECKS = getattr(settings, 'WATCHMAN_CHECKS', DEFAULT_CHECKS)
-
-if WATCHMAN_TOKEN:
-    warnings.warn("`WATCHMAN_TOKEN` setting is deprecated, use `WATCHMAN_TOKENS` instead. It will be removed in django-watchman 1.0.", DeprecationWarning)

--- a/watchman/settings.py
+++ b/watchman/settings.py
@@ -1,9 +1,12 @@
+import warnings
+
 from django.conf import settings
 
 # TODO: these should not be module level (https://github.com/mwarkentin/django-watchman/issues/13)
 WATCHMAN_ENABLE_PAID_CHECKS = getattr(settings, 'WATCHMAN_ENABLE_PAID_CHECKS', False)
 WATCHMAN_AUTH_DECORATOR = getattr(settings, 'WATCHMAN_AUTH_DECORATOR', 'watchman.decorators.token_required')
 WATCHMAN_TOKEN = getattr(settings, 'WATCHMAN_TOKEN', None)
+WATCHMAN_TOKENS = getattr(settings, 'WATCHMAN_TOKENS', None)
 WATCHMAN_TOKEN_NAME = getattr(settings, 'WATCHMAN_TOKEN_NAME', 'watchman-token')
 WATCHMAN_ERROR_CODE = getattr(settings, 'WATCHMAN_ERROR_CODE', 500)
 WATCHMAN_EMAIL_RECIPIENTS = getattr(settings, 'WATCHMAN_EMAIL_RECIPIENTS', ['to@example.com'])
@@ -22,3 +25,6 @@ if WATCHMAN_ENABLE_PAID_CHECKS:
     DEFAULT_CHECKS = DEFAULT_CHECKS + PAID_CHECKS
 
 WATCHMAN_CHECKS = getattr(settings, 'WATCHMAN_CHECKS', DEFAULT_CHECKS)
+
+if WATCHMAN_TOKEN:
+    warnings.warn("`WATCHMAN_TOKEN` setting is deprecated, use `WATCHMAN_TOKENS` instead. It will be removed in django-watchman 1.0.", DeprecationWarning)

--- a/watchman/views.py
+++ b/watchman/views.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+import warnings
 
 from django.db.transaction import non_atomic_requests
 from django.http import Http404
@@ -29,10 +30,17 @@ def _get_check_params(request):
     return (check_list, skip_list)
 
 
+def _deprecation_warnings():
+    if settings.WATCHMAN_TOKEN:
+        warnings.warn("`WATCHMAN_TOKEN` setting is deprecated, use `WATCHMAN_TOKENS` instead. It will be removed in django-watchman 1.0", DeprecationWarning)
+
+
 @auth
 @json_view
 @non_atomic_requests
 def status(request):
+    _deprecation_warnings()
+
     response = {}
     http_code = 200
 
@@ -64,6 +72,8 @@ def status(request):
 @auth
 @non_atomic_requests
 def dashboard(request):
+    _deprecation_warnings()
+
     check_types = []
 
     check_list, skip_list = _get_check_params(request)


### PR DESCRIPTION
* Add deprecation warning
* Update logic to handle both `WATCHMAN_TOKEN` and `WATCHMAN_TOKENS`
* Deprecate `WATCHMAN_TOKEN`
* Update readme
* Add tests for single / multiple tokens