### PR TITLE
Switch to int comparison for verbosity

### DIFF
--- a/watchman/management/commands/watchman.py
+++ b/watchman/management/commands/watchman.py
@@ -39,8 +39,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         check_list = None
         skip_list = None
-        verbosity = options['verbosity']
-        print_all_checks = verbosity in ['2', '3', ]
 
         checks = options['checks']
         skips = options['skips']
@@ -56,5 +54,6 @@ class Command(BaseCommand):
                 resp = json.dumps(check())
                 if '"ok": false' in resp:
                     raise CommandError(resp)
-                elif print_all_checks:
+                # Cast to int for Django < 1.8 (used to be a string value)
+                elif int(options['verbosity']) >= 2:
                     self.stdout.write(resp)


### PR DESCRIPTION
Fixes #98.

In Django 1.8, `options['verbosity']` switched from a string to an int,
breaking the way we were checking the value.

* https://github.com/django/django/commit/856863860352aa1f0288e6c9168a0e423c4f5184#diff-dfc45ab8548a0777543d12d6e77c9173L185
* https://github.com/django/django/blob/3c447b108ac70757001171f7a4791f493880bf5b/django/core/management/base.py#L240