### PR TITLE
Fixed a minor typo in the README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,8 +109,8 @@ to ``watchman.decorators.token_required``::
 
     WATCHMAN_AUTH_DECORATOR = 'django.contrib.admin.views.decorators.staff_member_required'
 
-Note that the ``token_required`` decorator does not protect a view unless the
-``WATCHMAN_TOKEN`` is set in settings.
+Note that the ``token_required`` decorator does not protect a view unless
+``WATCHMAN_TOKENS`` is set in settings.
 
 Custom checks
 *************


### PR DESCRIPTION
While reading through the main page of the docs, I noticed that `WATCH_TOKEN` gets referenced right after the deprecation warning that talks about how it was renamed to `WATCHMAN_TOKENS`. So I figured I'd throw together this quick PR to fix it.