### PR TITLE
Adds WATCHMAN_DISABLE_APM option

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,3 +23,4 @@ Contributors
 * Daniel Widerin - https://github.com/saily
 * Ryan Wilson-Perkin - https://github.com/ryanwilsonperkin
 * David Hoffman - https://github.com/dhoffman34
+* Ryan Verner - https://github.com/xfxf

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ History
 -------------------
 
 * [`#114 <https://github.com/mwarkentin/django-watchman/pull/114>`_] Add "bare" status view (@jamesmallen)
-* [`#115 <https://github.com/mwarkentin/django-watchman/pull/115>`_] Adds WATCHMAN_DISABLE_APM option (@xfxf)
+* [`#115 <https://github.com/mwarkentin/django-watchman/pull/115>`_] Adds ``WATCHMAN_DISABLE_APM`` option (@xfxf)
 
 0.14.0 (2018-01-09)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -247,6 +247,17 @@ Here is a simple example that would log to the console::
 More information is available in the `Django documentation
 <https://docs.djangoproject.com/en/2.0/topics/logging/#configuring-logging]>`_.
 
+New Relic Instrumentation
+*************************
+
+If you're using New Relic and watchman is being often for instance health checks
+(such as an ELB on AWS), you will likely find your average transaction time in
+New Relic will be affected greatly.
+
+You can disable instrumentation for watchman by using the ``WATCHMAN_NEWRELIC_IGNORE`` setting::
+
+    WATCHMAN_NEWRELIC_IGNORE = True
+
 Available checks
 ----------------
 

--- a/README.rst
+++ b/README.rst
@@ -247,16 +247,19 @@ Here is a simple example that would log to the console::
 More information is available in the `Django documentation
 <https://docs.djangoproject.com/en/2.0/topics/logging/#configuring-logging]>`_.
 
-New Relic Instrumentation
-*************************
+Instrumentation (i.e. New Relic)
+********************************
 
-If you're using New Relic and watchman is being often for instance health checks
-(such as an ELB on AWS), you will likely find your average transaction time in
-New Relic will be affected greatly.
+If you're using an instrumentation suite and watchman is being often for instance health checks
+(such as an ELB on AWS), you will likely find some stats based on averages will be affected
+(average transaction time, apdex, etc):
 
-You can disable instrumentation for watchman by using the ``WATCHMAN_NEWRELIC_IGNORE`` setting::
+You can disable instrumentation for watchman by using the ``WATCHMAN_DISABLE_APM`` setting::
 
-    WATCHMAN_NEWRELIC_IGNORE = True
+    WATCHMAN_DISABLE_APM = True
+
+This currently only supports the New Relic agent.
+
 
 Available checks
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -272,7 +272,7 @@ setting::
 
 This currently supports the following agents:
 
- * New Relic
+* New Relic
 
 Please open an issue if there's another APM you use which is being affected.
 

--- a/watchman/settings.py
+++ b/watchman/settings.py
@@ -15,6 +15,8 @@ WATCHMAN_EMAIL_HEADERS = getattr(settings, 'WATCHMAN_EMAIL_HEADERS', {})
 WATCHMAN_CACHES = getattr(settings, 'WATCHMAN_CACHES', settings.CACHES)
 WATCHMAN_DATABASES = getattr(settings, 'WATCHMAN_DATABASES', settings.DATABASES)
 
+WATCHMAN_NEWRELIC_IGNORE = getattr(settings, 'WATCHMAN_NEWRELIC_IGNORE', False)
+
 DEFAULT_CHECKS = (
     'watchman.checks.caches',
     'watchman.checks.databases',

--- a/watchman/settings.py
+++ b/watchman/settings.py
@@ -15,7 +15,7 @@ WATCHMAN_EMAIL_HEADERS = getattr(settings, 'WATCHMAN_EMAIL_HEADERS', {})
 WATCHMAN_CACHES = getattr(settings, 'WATCHMAN_CACHES', settings.CACHES)
 WATCHMAN_DATABASES = getattr(settings, 'WATCHMAN_DATABASES', settings.DATABASES)
 
-WATCHMAN_NEWRELIC_IGNORE = getattr(settings, 'WATCHMAN_NEWRELIC_IGNORE', False)
+WATCHMAN_DISABLE_APM = getattr(settings, 'WATCHMAN_DISABLE_APM', False)
 
 DEFAULT_CHECKS = (
     'watchman.checks.caches',

--- a/watchman/views.py
+++ b/watchman/views.py
@@ -35,13 +35,15 @@ def _deprecation_warnings():
         warnings.warn("`WATCHMAN_TOKEN` setting is deprecated, use `WATCHMAN_TOKENS` instead. It will be removed in django-watchman 1.0", DeprecationWarning)
 
 
-def _optional_newrelic_ignore_transaction():
-    if settings.WATCHMAN_NEWRELIC_IGNORE:
+def _optional_apm_ignore_transaction():
+    if settings.WATCHMAN_DISABLE_APM:
+
+        # New Relic
         try:
             import newrelic.agent
             newrelic.agent.ignore_transaction(flag=True)
         except ImportError:
-            warnings.warn("`WATCHMAN_NEWRELIC_IGNORE` is True but newrelic library could not be imported.")
+            warnings.warn("`WATCHMAN_DISABLE_APM` is True but newrelic library could not be imported.")
 
 
 @auth
@@ -55,7 +57,7 @@ def status(request):
 
     check_list, skip_list = _get_check_params(request)
 
-    _optional_newrelic_ignore_transaction()
+    _optional_apm_ignore_transaction()
 
     for check in get_checks(check_list=check_list, skip_list=skip_list):
         if callable(check):
@@ -83,7 +85,7 @@ def status(request):
 def ping(request):
     _deprecation_warnings()
 
-    _optional_newrelic_ignore_transaction()
+    _optional_apm_ignore_transaction()
 
     return HttpResponse('pong', content_type='text/plain')
 
@@ -97,7 +99,7 @@ def dashboard(request):
 
     check_list, skip_list = _get_check_params(request)
 
-    _optional_newrelic_ignore_transaction()
+    _optional_apm_ignore_transaction()
 
     for check in get_checks(check_list=check_list, skip_list=skip_list):
         if callable(check):

--- a/watchman/views.py
+++ b/watchman/views.py
@@ -35,6 +35,15 @@ def _deprecation_warnings():
         warnings.warn("`WATCHMAN_TOKEN` setting is deprecated, use `WATCHMAN_TOKENS` instead. It will be removed in django-watchman 1.0", DeprecationWarning)
 
 
+def _optional_newrelic_ignore_transaction():
+    if settings.WATCHMAN_NEWRELIC_IGNORE:
+        try:
+            import newrelic
+            newrelic.agent.ignore_transaction(flag=True)
+        except ImportError:
+            warnings.warn("`WATCHMAN_NEWRELIC_IGNORE` is True but newrelic library could not be imported.")
+
+
 @auth
 @json_view
 @non_atomic_requests
@@ -45,6 +54,8 @@ def status(request):
     http_code = 200
 
     check_list, skip_list = _get_check_params(request)
+
+    _optional_newrelic_ignore_transaction()
 
     for check in get_checks(check_list=check_list, skip_list=skip_list):
         if callable(check):
@@ -72,6 +83,8 @@ def status(request):
 def ping(request):
     _deprecation_warnings()
 
+    _optional_newrelic_ignore_transaction()
+
     return HttpResponse('pong', content_type='text/plain')
 
 
@@ -83,6 +96,8 @@ def dashboard(request):
     check_types = []
 
     check_list, skip_list = _get_check_params(request)
+
+    _optional_newrelic_ignore_transaction()
 
     for check in get_checks(check_list=check_list, skip_list=skip_list):
         if callable(check):

--- a/watchman/views.py
+++ b/watchman/views.py
@@ -38,7 +38,7 @@ def _deprecation_warnings():
 def _optional_newrelic_ignore_transaction():
     if settings.WATCHMAN_NEWRELIC_IGNORE:
         try:
-            import newrelic
+            import newrelic.agent
             newrelic.agent.ignore_transaction(flag=True)
         except ImportError:
             warnings.warn("`WATCHMAN_NEWRELIC_IGNORE` is True but newrelic library could not be imported.")


### PR DESCRIPTION
I've added a WATCHMAN_NEWRELIC_IGNORE option, which when enabled, disables instrumentation in the New Relic agent (used in many Django production installations) for any watchman calls.

This was done because I'm using watchman with ECS (on AWS) to monitor containers, and having watchman being hit multiple times every 30 seconds was causing a lot of New Relic stats that are based on averages to report totally inaccurately (throughput, apdex score, transaction times, etc) as the watchman queries end up being dominant.

There's no test, but I'm not clear how exactly I could test this outside of making the newrelic agent a dependency (which we don't want) or mocking the library completely (which makes me question what we're testing).  The code is written defensively.