### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ deploy:
   provider: pypi
   user: mwarkentin
   password:
-    secure: "nCd8+TIoZjsBw6b7w2T/EQduRL63f6aKdzdg2xR0tw2hdoByCmBVElbZlyuIbYkvg8FTVqnV4YnOoad4+Kg1pcqRbIa5YfpZTPv6IELXgvmCOZDlIoU1opV6By8RpIqu5NGXfoOcFbTmj8AfFAKkga1fwtUUDWBpl3VgTLAfcVI="
+    secure: "cQtAP8fMu+KzfBKG3ibTTXmDGZuz/FBp8RrLI8ddMGV4Jj5ElZLsvbqU43fiHbtVPV/uALDPF76WNGlpRH1P4w9m4XrFNCvkrnjtwIk7NZWi7uubWZcqQk9VE7MTP+i2IYrtNlGmlq1dbdJZcwS0mdzJcAAhAaP830Ekmqws9xE="
   distributions: "sdist bdist_wheel"
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,17 @@ sudo: false
 language: python
 
 python:
-  - "2.7"
-  - "3.5"
   - "3.6"
+  - "3.5"
+  - "2.7"
 
 env:
   matrix:
-    - DJANGO_VERSION=1.8
-    - DJANGO_VERSION=1.9
-    - DJANGO_VERSION=1.10
-    - DJANGO_VERSION=1.11
     - DJANGO_VERSION=2.0
+    - DJANGO_VERSION=1.11
+    - DJANGO_VERSION=1.10
+    - DJANGO_VERSION=1.9
+    - DJANGO_VERSION=1.8
 
 matrix:
   exclude:
@@ -34,7 +34,7 @@ notifications:
 
 jobs:
   include:
-    deploy:
+    - stage: deploy
       provider: pypi
       user: mwarkentin
       password:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,16 @@ language: python
 
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
+  - "3.6"
 
 env:
   matrix:
-    - DJANGO_VERSION=1.7
     - DJANGO_VERSION=1.8
     - DJANGO_VERSION=1.9
     - DJANGO_VERSION=1.10
-
-matrix:
-  exclude:
-    - python: "3.5"
-      env: DJANGO_VERSION=1.7
+    - DJANGO_VERSION=1.11
+    - DJANGO_VERSION=2.0
 
 install:
   - pip install tox coveralls
@@ -30,3 +26,12 @@ after_success: coveralls
 
 notifications:
   slack: tobalabs:XPt5OlsKuFGgIQZp0DpNXBUl
+
+deploy:
+  provider: pypi
+  user: mwarkentin
+  password:
+    secure: "nCd8+TIoZjsBw6b7w2T/EQduRL63f6aKdzdg2xR0tw2hdoByCmBVElbZlyuIbYkvg8FTVqnV4YnOoad4+Kg1pcqRbIa5YfpZTPv6IELXgvmCOZDlIoU1opV6By8RpIqu5NGXfoOcFbTmj8AfFAKkga1fwtUUDWBpl3VgTLAfcVI="
+  distributions: "sdist bdist_wheel"
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,14 @@ notifications:
 
 jobs:
   include:
-    - stage: deploy
-      provider: pypi
-      user: mwarkentin
-      password:
-        secure: "cQtAP8fMu+KzfBKG3ibTTXmDGZuz/FBp8RrLI8ddMGV4Jj5ElZLsvbqU43fiHbtVPV/uALDPF76WNGlpRH1P4w9m4XrFNCvkrnjtwIk7NZWi7uubWZcqQk9VE7MTP+i2IYrtNlGmlq1dbdJZcwS0mdzJcAAhAaP830Ekmqws9xE="
-      distributions: "sdist bdist_wheel"
-      on:
-        tags: true
+    - stage: pypi release
+      python: "3.6"
+      script: echo "Deploying to pypi ..."
+      deploy:
+        provider: pypi
+        user: mwarkentin
+        password:
+          secure: "cQtAP8fMu+KzfBKG3ibTTXmDGZuz/FBp8RrLI8ddMGV4Jj5ElZLsvbqU43fiHbtVPV/uALDPF76WNGlpRH1P4w9m4XrFNCvkrnjtwIk7NZWi7uubWZcqQk9VE7MTP+i2IYrtNlGmlq1dbdJZcwS0mdzJcAAhAaP830Ekmqws9xE="
+        distributions: "sdist bdist_wheel"
+        on:
+          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ env:
     - DJANGO_VERSION=1.11
     - DJANGO_VERSION=2.0
 
+matrix:
+  exclude:
+    - python: "2.7"
+      env: DJANGO_VERSION=2.0
+
 install:
   - pip install tox coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,13 @@ after_success: coveralls
 notifications:
   slack: tobalabs:XPt5OlsKuFGgIQZp0DpNXBUl
 
-deploy:
-  provider: pypi
-  user: mwarkentin
-  password:
-    secure: "cQtAP8fMu+KzfBKG3ibTTXmDGZuz/FBp8RrLI8ddMGV4Jj5ElZLsvbqU43fiHbtVPV/uALDPF76WNGlpRH1P4w9m4XrFNCvkrnjtwIk7NZWi7uubWZcqQk9VE7MTP+i2IYrtNlGmlq1dbdJZcwS0mdzJcAAhAaP830Ekmqws9xE="
-  distributions: "sdist bdist_wheel"
-  on:
-    tags: true
+jobs:
+  include:
+    deploy:
+      provider: pypi
+      user: mwarkentin
+      password:
+        secure: "cQtAP8fMu+KzfBKG3ibTTXmDGZuz/FBp8RrLI8ddMGV4Jj5ElZLsvbqU43fiHbtVPV/uALDPF76WNGlpRH1P4w9m4XrFNCvkrnjtwIk7NZWi7uubWZcqQk9VE7MTP+i2IYrtNlGmlq1dbdJZcwS0mdzJcAAhAaP830Ekmqws9xE="
+      distributions: "sdist bdist_wheel"
+      on:
+        tags: true

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -1,0 +1,23 @@
+=========
+Releasing
+=========
+
+Releases are created via Travis or uploaded locally using `twine <https://github.com/pypa/twine]>`_.
+
+When the release is ready to go:
+
+* Make sure ``HISTORY.rst`` and other documentation is up to date
+* Bump version in ``watchman/__init__.py``
+* Tag code: ``git tag 1.0.0``
+* Push tag: ``git push origin 1.0.0``
+
+Travis will run the full test suite and deploy to pypi in a separate stage if everything passes.
+
+Local fallback
+~~~~~~~~~~~~~~
+
+If Travis isn't available or working for releases for some reason, you can use `twine <https://github.com/pypa/twine]>`_ to upload the release.
+
+* Install and configure `twine <https://github.com/pypa/twine]>`_
+* Check dist locally: ``make dist``
+* Deploy release: ``make release``

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     covclean,
-    py{27,34}-dj{17,18,19,110},
-    py35-dj{18,19,110},
+    py27-dj{18,19,110,111},
+    py{35,36}-dj{18,19,110,111,20},
     coverage
 
 [testenv]
@@ -10,10 +10,11 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/watchman
 commands = coverage run --parallel --source watchman runtests.py {posargs}
 deps =
-    dj17: Django>=1.7,<1.8
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
-    dj110: Django==1.10rc1
+    dj110: Django>=1.10,<1.11
+    dj111: Django>=1.11,<2.0
+    dj20: Django>=2.0,<2.1
     -r{toxinidir}/requirements-test.txt
 
 [testenv:covclean]

--- a/watchman/__init__.py
+++ b/watchman/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '0.15.0'
+__version__ = '1.0.0-test'

--- a/watchman/__init__.py
+++ b/watchman/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '1.0.0-test'
+__version__ = '0.15.0'


### PR DESCRIPTION
* Replace python 3.4 with 3.6
* Drop django 1.7, add 1.11 and 2.0
* Configure travis to deploy to pypi after tests
* Add release documentation