### PR TITLE
Added a tag to remove whitespace from Traceback modal ids

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,11 @@
 History
 =======
 
+1.0.1 (YYYY-MM-DD)
+------------------
+
+* Fix modal popups on dashboards when Type or Name fields contains spaces (@maikeps)
+
 1.0.0 (2019-12-18)
 -------------------
 

--- a/watchman/templates/watchman/dashboard.html
+++ b/watchman/templates/watchman/dashboard.html
@@ -58,7 +58,7 @@
                     {% trans "ERROR!" %}
 
                     <div class="btn-group btn-group-xs pull-right">
-                        <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#{{ type_name }}{% if status.name %}-{{ status.name }}{% endif %}">{% trans "Traceback" %}</button>
+                        <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#{{ type_name|cut:' ' }}{% if status.name %}-{{ status.name|cut:' ' }}{% endif %}">{% trans "Traceback" %}</button>
                     </div>
                 </td>
                 {% endif %}{# status.ok #}
@@ -80,12 +80,12 @@
 {% for type_name, type in checks.items %}
 {% for status in type.statuses %}
 {% if not status.ok %}
-<div class="modal fade" id="{{ type_name }}{% if status.name %}-{{ status.name }}{% endif %}" tabindex="-1" role="dialog" aria-labelledby="{{ type_name }}{% if status.name %}-{{ status.name }}{% endif %}-title">
+<div class="modal fade" id="{{ type_name|cut:' ' }}{% if status.name %}-{{ status.name|cut:' ' }}{% endif %}" tabindex="-1" role="dialog" aria-labelledby="{{ type_name|cut:' ' }}{% if status.name %}-{{ status.name|cut:' ' }}{% endif %}-title">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h4 class="modal-title" id="{{ type_name }}{% if status.name %}-{{ status.name }}{% endif %}-title">{{ type_name|title }}{% if status.name %} - {{ status.name|title }}{% endif %}</h4>
+                <h4 class="modal-title" id="{{ type_name|cut:' ' }}{% if status.name %}-{{ status.name|cut:' ' }}{% endif %}-title">{{ type_name|title }}{% if status.name %} - {{ status.name|title }}{% endif %}</h4>
             </div><!-- class="modal-header" -->
             <div class="modal-body">
                 <h4><pre>{{ status.error }}</pre></h4>


### PR DESCRIPTION
The Traceback modals weren't opening when either the "Type" or the "Name" fields contained any spaces in them (for instance, if I had a database named "Database 2", it wouldn't work). 

Upon code inspection, I found that the modal ids were being built based on those fields, so in the example database, the id would be "#Database 2", which caused the modal to not open on button click. 

So to fix that, I added a cut tag in those fields on the html template to properly build the modal id.