### PR TITLE
Cache imported check modules

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,9 +11,11 @@ from __future__ import unicode_literals
 
 import unittest
 
+from django.utils.module_loading import import_string
+
 from unittest.mock import patch
 
-from watchman.utils import get_cache, get_checks
+from watchman.utils import get_cache, get_checks, import_check
 
 
 class TestWatchman(unittest.TestCase):
@@ -69,3 +71,12 @@ class TestWatchman(unittest.TestCase):
     @unittest.skip("Unsure how to test w/ modified settings")
     def test_get_checks_with_paid_checks_enabled_returns_expected_checks(self):
         pass
+
+    @patch("watchman.utils.import_string", wraps=import_string)
+    @patch("watchman.utils.imported_checks", {})
+    def test_import_check_imports_once(self, spy_import_string):
+        check = import_check('watchman.checks.caches')
+        check2 = import_check('watchman.checks.caches')
+        self.assertEqual(check.__name__, 'caches')
+        self.assertEqual(check2.__name__, 'caches')
+        self.assertEqual(spy_import_string.call_count, 1)

--- a/watchman/utils.py
+++ b/watchman/utils.py
@@ -6,6 +6,15 @@ from django.utils.module_loading import import_string
 from watchman.settings import WATCHMAN_CHECKS
 
 
+imported_checks = {}
+
+
+def import_check(python_path):
+    if python_path not in imported_checks:
+        imported_checks[python_path] = import_string(python_path)
+    return imported_checks[python_path]
+
+
 def get_cache(cache_name):
     return django_cache.caches[cache_name]
 
@@ -19,4 +28,4 @@ def get_checks(check_list=None, skip_list=None):
         checks_to_run = checks_to_run.difference(skip_list)
 
     for python_path in checks_to_run:
-        yield import_string(python_path)
+        yield import_check(python_path)


### PR DESCRIPTION
Calling `import_string` every time the checks are run is not very performant, caching those imports makes subsequent runs much faster.

In local tests the original code was taking ~200ms for each request to `/watchman/`. With the changed code all request after the first took ~7ms.