### PR TITLE
Replace deprecated url() calls with re_path()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Quickstart
 
 3. Include the watchman URLconf in your project ``urls.py`` like this::
 
-    url(r'^watchman/', include('watchman.urls')),
+    re_path(r'^watchman/', include('watchman.urls')),
 
 4. Start the development server and visit ``http://127.0.0.1:8000/watchman/`` to
    get a JSON response of your backing service statuses::
@@ -194,7 +194,7 @@ can use the ``bare_status`` view by putting the following into ``urls.py``::
 
     import watchman.views
     # ...
-    url(r'^status/?$', watchman.views.bare_status),
+    re_path(r'^status/?$', watchman.views.bare_status),
 
 Django management command
 *************************
@@ -355,10 +355,10 @@ Remember that this must be within the ``MEDIA_ROOT``, which by default is your p
   WATCHMAN_STORAGE_PATH = "/path_to_your_app/foo/bar/"
 
 If the ``MEDIA_ROOT`` is already defined::
- 
+
   from os.path import join as joinpath
   WATCHMAN_STORAGE_PATH = joinpath(MEDIA_ROOT, "foo/bar")
-    
+
 Default checks
 **************
 

--- a/sample_project/sample_project/urls.py
+++ b/sample_project/sample_project/urls.py
@@ -5,21 +5,21 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', Home.as_view(), name='home')
 Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    2. Add a URL to urlpatterns:  re_path(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.contrib import admin
 import watchman.views
 
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^watchman/', include('watchman.urls')),
-    url(r'^watchman/bare/', watchman.views.bare_status, name='bare_status'),
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^watchman/', include('watchman.urls')),
+    re_path(r'^watchman/bare/', watchman.views.bare_status, name='bare_status'),
 ]

--- a/watchman/urls.py
+++ b/watchman/urls.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from django.conf.urls import url
+from django.urls import re_path
 
 from watchman import views
 
 
 urlpatterns = [
-    url(r'^$', views.status, name="status"),
-    url(r'^dashboard/$', views.dashboard, name="dashboard"),
-    url(r'^ping/$', views.ping, name="ping"),
+    re_path(r'^$', views.status, name="status"),
+    re_path(r'^dashboard/$', views.dashboard, name="dashboard"),
+    re_path(r'^ping/$', views.ping, name="ping"),
 ]


### PR DESCRIPTION
Calls to url() are deprecated since Django 3.1 and are supposed
to be replaced with re_path().