### PR TITLE
Improve database check performance: replace introspection.table_names() by a simple cursor query

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Unreleased
 ----------
 
 * [`#181 <https://github.com/mwarkentin/django-watchman/pull/181>`_] Update sample project to Django 4.x
+* [`#171 <https://github.com/mwarkentin/django-watchman/pull/171>`_] Improve database check performance: replace introspection.table_names() by a simple cursor query (@cristianemoyano)
 
 1.2.0 (2020-09-20)
 ------------------

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -12,10 +12,10 @@ from __future__ import unicode_literals
 import logging
 import unittest
 from unittest import mock
+from unittest.mock import MagicMock, patch
 
 from django.test.client import Client
 from django.urls import reverse
-from unittest.mock import MagicMock, patch
 
 from watchman import settings as watchman_settings
 from watchman.decorators import check
@@ -30,15 +30,16 @@ class TestDBConnection(unittest.TestCase):
     def setUp(self):
         self.client = Client()
 
-    @patch('watchman.checks.connections')
+    @patch("watchman.checks.connections")
     def test_cursor_is_called(self, mock_connections):
         cursor_mock = MagicMock()
-        mock_connections['default'].cursor().__enter__.return_value = cursor_mock
+        mock_connections["default"].cursor().__enter__.return_value = cursor_mock
         data = {
-            'watchman-token': 't1',
+            "watchman-token": "t1",
         }
-        self.client.get(reverse('status'), data)
-        cursor_mock.execute.assert_called_once_with('SELECT 1')
+        self.client.get(reverse("status"), data)
+        cursor_mock.execute.assert_called_once_with("SELECT 1")
+
 
 class TestWatchmanMultiTokens(unittest.TestCase):
     def setUp(self):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -14,7 +14,7 @@ import unittest
 from unittest import mock
 
 from django.test.client import Client
-from django.urls import reverse
+from unittest.mock import MagicMock, patch
 
 from watchman import settings as watchman_settings
 from watchman.decorators import check
@@ -37,6 +37,17 @@ class TestWatchmanMultiTokens(unittest.TestCase):
         }
         response = self.client.get(reverse("status"), data)
         self.assertEqual(response.status_code, 200)
+
+    @patch('django.db.connections')
+    def test_cursor_is_called(self, mock_connections):
+        cursor_mock = MagicMock()
+        mock_connections['default'].cursor().__enter__.return_value = cursor_mock
+        data = {
+            'watchman-token': 't1',
+        }
+        self.client.get(reverse('status'), data)
+        cursor_mock.execute.assert_called_once_with('SELECT 1')
+
 
     def test_200_ok_if_matching_second_token_in_list(self):
         data = {

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -30,7 +30,7 @@ class TestDBConnection(unittest.TestCase):
     def setUp(self):
         self.client = Client()
 
-    @patch('django.db.connections')
+    @patch('watchman.checks.connections')
     def test_cursor_is_called(self, mock_connections):
         cursor_mock = MagicMock()
         mock_connections['default'].cursor().__enter__.return_value = cursor_mock

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -14,6 +14,7 @@ import unittest
 from unittest import mock
 
 from django.test.client import Client
+from django.urls import reverse
 from unittest.mock import MagicMock, patch
 
 from watchman import settings as watchman_settings
@@ -24,6 +25,20 @@ class FakeException(Exception):
     def __init__(self, *args, **kwargs):
         super(self.__class__, self).__init__(*args, **kwargs)
 
+
+class TestDBConnection(unittest.TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    @patch('django.db.connections')
+    def test_cursor_is_called(self, mock_connections):
+        cursor_mock = MagicMock()
+        mock_connections['default'].cursor().__enter__.return_value = cursor_mock
+        data = {
+            'watchman-token': 't1',
+        }
+        self.client.get(reverse('status'), data)
+        cursor_mock.execute.assert_called_once_with('SELECT 1')
 
 class TestWatchmanMultiTokens(unittest.TestCase):
     def setUp(self):
@@ -37,17 +52,6 @@ class TestWatchmanMultiTokens(unittest.TestCase):
         }
         response = self.client.get(reverse("status"), data)
         self.assertEqual(response.status_code, 200)
-
-    @patch('django.db.connections')
-    def test_cursor_is_called(self, mock_connections):
-        cursor_mock = MagicMock()
-        mock_connections['default'].cursor().__enter__.return_value = cursor_mock
-        data = {
-            'watchman-token': 't1',
-        }
-        self.client.get(reverse('status'), data)
-        cursor_mock.execute.assert_called_once_with('SELECT 1')
-
 
     def test_200_ok_if_matching_second_token_in_list(self):
         data = {

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -80,14 +80,16 @@ class TestWatchman(unittest.TestCase):
     def test_check_database_handles_exception(self):
         response = checks._check_database("foo")
         self.assertFalse(response["foo"]["ok"])
-        self.assertEqual(response["foo"]["error"], "The connection foo doesn't exist")
+        self.assertEqual(
+            response["foo"]["error"], "The connection 'foo' doesn't exist."
+        )
 
     def test_check_cache_handles_exception(self):
         response = checks._check_cache("foo")
         self.assertFalse(response["foo"]["ok"])
         self.assertIn(
             response["foo"]["error"],
-            "Could not find config for 'foo' in settings.CACHES",
+            "The connection 'foo' doesn't exist.",
         )
 
     def test_response_skipped_checks(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -81,14 +81,13 @@ class TestWatchman(unittest.TestCase):
         response = checks._check_database("foo")
         self.assertFalse(response["foo"]["ok"])
         self.assertEqual(
-            response["foo"]["error"], "The connection 'foo' doesn't exist."
+            response["foo"]["error"], "The connection foo doesn't exist"
         )
 
     def test_check_cache_handles_exception(self):
-
         response = checks._check_cache("foo")
         self.assertFalse(response["foo"]["ok"])
-        self.assertIn(response["foo"]["error"], "The connection 'foo' doesn't exist.")
+        self.assertIn(response["foo"]["error"], "Could not find config for 'foo' in settings.CACHES")
 
     def test_response_skipped_checks(self):
         expected_checks = [

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -80,14 +80,15 @@ class TestWatchman(unittest.TestCase):
     def test_check_database_handles_exception(self):
         response = checks._check_database("foo")
         self.assertFalse(response["foo"]["ok"])
-        self.assertEqual(
-            response["foo"]["error"], "The connection foo doesn't exist"
-        )
+        self.assertEqual(response["foo"]["error"], "The connection foo doesn't exist")
 
     def test_check_cache_handles_exception(self):
         response = checks._check_cache("foo")
         self.assertFalse(response["foo"]["ok"])
-        self.assertIn(response["foo"]["error"], "Could not find config for 'foo' in settings.CACHES")
+        self.assertIn(
+            response["foo"]["error"],
+            "Could not find config for 'foo' in settings.CACHES",
+        )
 
     def test_response_skipped_checks(self):
         expected_checks = [

--- a/watchman/checks.py
+++ b/watchman/checks.py
@@ -38,7 +38,9 @@ def _check_databases(databases):
 
 @check
 def _check_database(database):
-    connections[database].introspection.table_names()
+    connection = connections[database]
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT 1")
     return {database: {"ok": True}}
 
 


### PR DESCRIPTION
## Summary

The `introspection.table_names()` method in Django could produce a poor performance in large databases.

Take a look at the different backends implementations:
- https://github.com/django/django/blob/0b95a96ee10d3e12aef01d449467bcf4641286b4/django/db/backends/mysql/introspection.py#L67
- https://github.com/django/django/blob/0b95a96ee10d3e12aef01d449467bcf4641286b4/django/db/backends/sqlite3/introspection.py#L70
- https://github.com/django/django/blob/0b95a96ee10d3e12aef01d449467bcf4641286b4/django/db/backends/postgresql/introspection.py#L47
- https://github.com/django/django/blob/0b95a96ee10d3e12aef01d449467bcf4641286b4/django/db/backends/oracle/introspection.py#L72

That's why I suggest executing a cheap query: `SELECT 1 ` to test the database connection.

## Testing

`python runtests.py tests/test_decorators.py:TestDBConnection`

```
(django-watchman) ➜  django-watchman git:(improve-database-check-performance) ✗ python runtests.py
nosetests tests -s --verbosity=1
Creating test database for alias 'default'...
...............................S............................
----------------------------------------------------------------------
Ran 60 tests in 0.158s

OK (SKIP=1)
Destroying test database for alias 'default'...
```