### PR TITLE
Automate PyPI publishing with GitHub Actions trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  ci:
+    # Run the full CI suite before publishing
+    uses: ./.github/workflows/ci.yml
+
+  build:
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Build package
+        run: uv build
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # Required for trusted publishing via OIDC
+      contents: write # Required to upload assets to the GitHub Release
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No API token needed -- uses OIDC trusted publishing
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --repo "${{ github.repository }}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,19 +1,32 @@
 # Releasing
 
-Releases are created via GitHub Actions (soon: <https://github.com/mwarkentin/django-watchman/issues/177>) or uploaded locally using [twine](https://github.com/pypa/twine).
+Releases are published to PyPI automatically via GitHub Actions using [trusted publishing](https://docs.pypi.org/trusted-publishers/).
 
-When the release is ready to go:
+## Release steps
 
-- Make sure `CHANGELOG.md` and other documentation is up to date
-- Bump version in `watchman/__init__.py`
-- Tag code: `git tag 1.0.0`
-- Push tag: `git push origin 1.0.0`
-- Create a release from the tag on GitHub
+1. Update `CHANGELOG.md` -- move items from "Unreleased" into a new version section with today's date
+2. Bump `__version__` in `watchman/__init__.py` (this is the single source of version truth)
+3. Commit the changes: `git commit -am "Release X.Y.Z"`
+4. Tag the commit: `git tag X.Y.Z`
+5. Push the commit and tag: `git push origin main --tags`
+6. [Create a GitHub Release](https://github.com/mwarkentin/django-watchman/releases/new) from the tag -- paste the changelog entry as the release notes
+7. The publish workflow will automatically run CI, build the package, publish to PyPI, and attach the artifacts to the release
 
 ## Local fallback
 
-If GitHub Actions isn't available or working for releases for some reason, you can use [twine](https://github.com/pypa/twine) to upload the release.
+If GitHub Actions isn't available or working for some reason, you can publish locally:
 
-- Install and configure [twine](https://github.com/pypa/twine)
-- Check dist locally: `just dist`
-- Deploy release: `just release`
+- Check the dist locally: `just dist`
+- Publish the release: `just release`
+
+## One-time PyPI trusted publishing setup
+
+To enable automated publishing, the repository maintainer needs to configure trusted publishing:
+
+1. Go to the [django-watchman PyPI project settings](https://pypi.org/manage/project/django-watchman/settings/publishing/)
+2. Add a new "Trusted Publisher" with:
+   - **Owner**: `mwarkentin`
+   - **Repository**: `django-watchman`
+   - **Workflow name**: `publish.yml`
+   - **Environment name**: `pypi`
+3. In the [GitHub repository settings](https://github.com/mwarkentin/django-watchman/settings/environments), create an environment named `pypi` (optionally with deployment protection rules for an approval gate)

--- a/justfile
+++ b/justfile
@@ -43,12 +43,18 @@ docs:
 docs-build:
     uv run --group docs mkdocs build --strict
 
-# Package and upload a release
+# Bump version in watchman/__init__.py
+bump version:
+    sed -i '' 's/__version__ = ".*"/__version__ = "{{ version }}"/' watchman/__init__.py
+    @echo "Version bumped to {{ version }}"
+    @grep __version__ watchman/__init__.py
+
+# Package and upload a release (local fallback - prefer GitHub Actions)
 release: clean lint test
     uv build
     uv publish
 
-# Package a release
+# Package a release (without publishing)
 dist: clean lint test
     uv build
     ls -l dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-watchman"
-version = "1.3.0"
+dynamic = ["version"]
 description = "django-watchman exposes a status endpoint for your backing services"
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -51,6 +51,9 @@ docs = [
 mysql = [
     "mysqlclient>=2.0",
 ]
+
+[tool.hatch.version]
+path = "watchman/__init__.py"
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
- Add publish workflow triggered on GitHub Release, using OIDC trusted publishing (no API tokens needed)
- Make CI workflow reusable via workflow_call for publish prerequisites
- Eliminate version duplication: pyproject.toml now reads version dynamically from watchman/__init__.py via Hatchling
- Add `just bump` recipe for convenient version updates
- Rewrite RELEASING.md with streamlined process and setup instructions